### PR TITLE
Jira-224 port avr/pgmspace.h

### DIFF
--- a/cores/arduino/avr/pgmspace.h
+++ b/cores/arduino/avr/pgmspace.h
@@ -1,0 +1,69 @@
+/*
+pgmspace.c wrapper for Intel maker boards
+Copyright (C) 2014 Intel Corporation
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Author: Mikal Hart
+ */
+
+#ifdef __ARDUINO_ARC__
+
+#ifndef __PGMSPACE_H_
+#define __PGMSPACE_H_ 1
+
+#include <inttypes.h>
+
+#define PROGMEM
+#define PGM_P  const char *
+#define PSTR(str) (str)
+
+#define _SFR_BYTE(n) (n)
+
+typedef void prog_void;
+typedef char prog_char;
+typedef unsigned char prog_uchar;
+typedef int8_t prog_int8_t;
+typedef uint8_t prog_uint8_t;
+typedef int16_t prog_int16_t;
+typedef uint16_t prog_uint16_t;
+typedef int32_t prog_int32_t;
+typedef uint32_t prog_uint32_t;
+
+#define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
+#define strcpy_P(dest, src) strcpy((dest), (src))
+#define strcat_P(dest, src) strcat((dest), (src))
+#define strcmp_P(a, b) strcmp((a), (b))
+#define strstr_P(a, b) strstr((a), (b))
+#define strlen_P(s) strlen((const char *)(s))
+#define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
+
+#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+#define pgm_read_word(addr) (*(const unsigned short *)(addr))
+#define pgm_read_dword(addr) (*(const unsigned long *)(addr))
+#define pgm_read_float(addr) (*(const float *)(addr))
+
+#define pgm_read_byte_near(addr) pgm_read_byte(addr)
+#define pgm_read_word_near(addr) pgm_read_word(addr)
+#define pgm_read_dword_near(addr) pgm_read_dword(addr)
+#define pgm_read_float_near(addr) pgm_read_float(addr)
+#define pgm_read_byte_far(addr) pgm_read_byte(addr)
+#define pgm_read_word_far(addr) pgm_read_word(addr)
+#define pgm_read_dword_far(addr) pgm_read_dword(addr)
+#define pgm_read_float_far(addr) pgm_read_float(addr)
+
+#endif  // __PGMSPACE_H_
+
+#endif  // __ARDUINO_X86__

--- a/platform.txt
+++ b/platform.txt
@@ -14,12 +14,12 @@ compiler.prefix=arc-elf32
 
 compiler.path={runtime.tools.arc-elf32.path}/bin/
 compiler.c.cmd=arc-elf32-gcc
-compiler.c.flags=-c -mARCv2EM -mav2em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -MMD
+compiler.c.flags=-c -mARCv2EM -mav2em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -MMD -D__ARDUINO_ARC__
 compiler.c.elf.cmd=arc-elf32-gcc
 compiler.c.elf.flags=-nostartfiles -nodefaultlibs -nostdlib -static -Wl,-X -Wl,-N -Wl,-mARCv2EM -Wl,-marcelf -Wl,--gc-sections
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=arc-elf32-g++
-compiler.cpp.flags=-c -mARCv2EM -mav2em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -MMD -fno-rtti -fno-exceptions
+compiler.cpp.flags=-c -mARCv2EM -mav2em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -MMD -fno-rtti -fno-exceptions -D__ARDUINO_ARC__
 compiler.ar.cmd=arc-elf32-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arc-elf32-objcopy


### PR DESCRIPTION
many libraries fail to compile because they need avr/pgmspace.h.
Galileo/Edison had the same issue and the same code can be ported over.
