### PR TITLE
WStrings: add c_str function

### DIFF
--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -151,6 +151,7 @@ public:
 	void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index=0) const;
 	void toCharArray(char *buf, unsigned int bufsize, unsigned int index=0) const
 		{getBytes((unsigned char *)buf, bufsize, index);}
+	const char * c_str() const { return buffer; }
 
 	// search
 	int indexOf( char ch ) const;


### PR DESCRIPTION
this fixes SD library compilation

However, in the long term, WString, Print, IPAddress, Stream and WMath (every core file non hardware-related) should be aligned to AVR version to avoid incompatibilities with derived classes
