### PR TITLE
WString class fixes

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -27,7 +27,7 @@
 #include <math.h>
 
 #include "binary.h"
-#include "itoa.h"
+//#include "itoa.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -78,56 +78,11 @@ String::String(char c)
 	*this = buf;
 }
 
-static char * c_spec_signed[] = {
-		(char *) "%d",
-		(char *) "%ld",
-		(char *) "%o",
-		(char *) "%x",
-		(char *) "unsupported base",
-	};
-
-static char * c_spec_unsigned[] = {
-		(char *) "%u",
-		(char *) "%lu",
-		(char *) "%o",
-		(char *) "%x",
-		(char *) "unsupported base",
-	};
-
-
-char * String::getCSpec(int base, bool issigned, bool islong){
-	int int_idx = 0;
-
-	if(islong == true)
-		int_idx = 1;
-
-	switch(base){
-		case 8:
-			if(issigned == true)
-				return c_spec_signed[2];
-			else
-				return c_spec_unsigned[2];
-		case 10:
-			if(issigned == true)
-				return c_spec_signed[int_idx];
-			else
-				return c_spec_unsigned[int_idx];
-		case 16:
-			if(issigned == true)
-				return c_spec_signed[3];
-			else
-				return c_spec_unsigned[3];
-		default:
-			return c_spec_unsigned[4];
-	}
-};
-
 String::String(unsigned char value, unsigned char base)
 {
 	init();
 	char buf[1 + 8 * sizeof(unsigned char)];
-	//utoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, false, false), value);
+	utoa(value, buf, base);
 	*this = buf;
 }
 
@@ -135,8 +90,7 @@ String::String(int value, unsigned char base)
 {
 	init();
 	char buf[2 + 8 * sizeof(int)];
-	//itoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, true, false), value);
+	itoa(value, buf, base);
 	*this = buf;
 }
 
@@ -144,8 +98,7 @@ String::String(unsigned int value, unsigned char base)
 {
 	init();
 	char buf[1 + 8 * sizeof(unsigned int)];
-	//utoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, false, false), value);
+	utoa(value, buf, base);
 	*this = buf;
 }
 
@@ -153,8 +106,7 @@ String::String(long value, unsigned char base)
 {
 	init();
 	char buf[2 + 8 * sizeof(long)];
-	//ltoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, true, true), value);
+	ltoa(value, buf, base);
 	*this = buf;
 }
 
@@ -162,8 +114,7 @@ String::String(unsigned long value, unsigned char base)
 {
 	init();
 	char buf[1 + 8 * sizeof(unsigned long)];
-	//ultoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, false, true), value);
+	ultoa(value, buf, base);
 	*this = buf;
 }
 
@@ -171,8 +122,7 @@ String::String(long long value, unsigned char base)
 {
 	init();
 	char buf[2 + 8 * sizeof(long long)];
-	//ltoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, true, true), value);
+	ltoa(value, buf, base);
 	*this = buf;
 }
 
@@ -180,8 +130,7 @@ String::String(unsigned long long value, unsigned char base)
 {
 	init();
 	char buf[1 + 8 * sizeof(unsigned long long)];
-	//ultoa(value, buf, base);
-	snprintf(buf, sizeof(buf), getCSpec(base, false, true), value);
+	ultoa(value, buf, base);
 	*this = buf;
 }
 
@@ -189,20 +138,14 @@ String::String(float value, unsigned char decimalPlaces)
 {
 	init();
 	char buf[33];
-	String dec(decimalPlaces);
-	String tmp = "%." + dec + "f";
-	snprintf(buf, sizeof(buf), tmp.c_str(), value);
-	*this = buf;
+	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces)
 {
-        init();
-        char buf[33];
-        String dec(decimalPlaces);
-        String tmp = "%." + dec + "f";
-        snprintf(buf, sizeof(buf), tmp.c_str(), value);
-        *this = buf;
+	init();
+	char buf[33];
+	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
 String::~String()
@@ -328,11 +271,11 @@ unsigned char String::concat(const String &s)
 	return concat(s.buffer, s.len);
 }
 
-unsigned char String::concat(const char *cstr, unsigned int _length)
+unsigned char String::concat(const char *cstr, unsigned int length)
 {
-	unsigned int newlen = len + _length;
+	unsigned int newlen = len + length;
 	if (!cstr) return 0;
-	if (_length == 0) return 1;
+	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
 	strcpy(buffer + len, cstr);
 	len = newlen;
@@ -356,71 +299,64 @@ unsigned char String::concat(char c)
 unsigned char String::concat(unsigned char num)
 {
 	char buf[1 + 3 * sizeof(unsigned char)];
-	//itoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, true, false), num);
+	itoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(int num)
 {
 	char buf[2 + 3 * sizeof(int)];
-	//itoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, true, false), num);
+	itoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned int num)
 {
 	char buf[1 + 3 * sizeof(unsigned int)];
-	//utoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, false, false), num);
+	utoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(long num)
 {
 	char buf[2 + 3 * sizeof(long)];
-	//ltoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, true, true), num);
+	ltoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned long num)
 {
 	char buf[1 + 3 * sizeof(unsigned long)];
-	//ultoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, false, true), num);
+	ultoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(long long num)
 {
-	char buf[12];
-	//ltoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, true, true), num);
+	char buf[2 + 3 * sizeof(long long)];
+	ltoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned long long num)
 {
-	char buf[11];
-	//ultoa(num, buf, 10);
-	snprintf(buf, sizeof(buf), getCSpec(10, false, true), num);
+	char buf[1 + 3 * sizeof(unsigned long long)];
+	ultoa(num, buf, 10);
 	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(float num)
 {
 	char buf[20];
-	snprintf(buf, sizeof(buf), "%f", num);
-	return concat(buf, strlen(buf));
+	char* string = dtostrf(num, 4, 2, buf);
+	return concat(string, strlen(string));
 }
 
 unsigned char String::concat(double num)
 {
-        char buf[20];
-        snprintf(buf, sizeof(buf), "%f", num);
-        return concat(buf, strlen(buf));
+	char buf[20];
+	char* string = dtostrf(num, 4, 2, buf);
+	return concat(string, strlen(string));
 }
 
 /*********************************************/

--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "stdlib_noniso.h"
 //#include <avr/pgmspace.h>
 
 // When compiling programs with this class, the following gcc parameters

--- a/cores/arduino/stdlib_noniso.cpp
+++ b/cores/arduino/stdlib_noniso.cpp
@@ -1,0 +1,201 @@
+/* 
+ core_esp8266_noniso.c - nonstandard (but usefull) conversion functions
+ Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Modified 03 April 2015 by Markus Sattler
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "stdlib_noniso.h"
+#include "math.h"
+#include "inttypes.h"
+
+int atoi(const char* s) {
+    return (int) atol(s);
+}
+
+long atol(const char* s) {
+    char * tmp;
+    return strtol(s, &tmp, 10);
+}
+
+double atof(const char* s) {
+    char * tmp;
+    return strtod(s, &tmp);
+}
+
+void reverse(char* begin, char* end) {
+    char *is = begin;
+    char *ie = end - 1;
+    while(is < ie) {
+        char tmp = *ie;
+        *ie = *is;
+        *is = tmp;
+        ++is;
+        --ie;
+    }
+}
+
+char* itoa(int value, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    int quotient = abs(value);
+
+    do {
+        const int tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    // Apply negative sign
+    if(value < 0)
+        *out++ = '-';
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
+char* ltoa(long value, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    long quotient = abs(value);
+
+    do {
+        const long tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    // Apply negative sign
+    if(value < 0)
+        *out++ = '-';
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
+char* utoa(unsigned value, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    unsigned quotient = value;
+
+    do {
+        const unsigned tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
+char* ultoa(unsigned long value, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    unsigned long quotient = value;
+
+    do {
+        const unsigned long tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
+char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
+
+    if (isnan(number)) {
+        strcpy(s, "nan");
+        return s;
+    }
+    if (isinf(number)) {
+        strcpy(s, "inf");
+        return s;
+    }
+
+    if (number > 4294967040.0 || number < -4294967040.0) {
+        strcpy(s, "ovf");
+        return s;
+    }
+
+    char* out = s;
+    int signInt_Part = 1;
+
+    // Handle negative numbers
+    if (number < 0.0) {
+        signInt_Part = -1;
+        number = -number;
+    }
+
+    // calc left over digits 
+    if (prec > 0)
+    {
+        width -= (prec + 1);
+    }
+
+    // Round correctly so that print(1.999, 2) prints as "2.00"
+    double rounding = 0.5;
+    for (uint8_t i = 0; i < prec; ++i)
+        rounding /= 10.0;
+
+    number += rounding;
+
+    // Extract the integer part of the number and print it
+    unsigned long int_part = (unsigned long)number;
+    double remainder = number - (double)int_part;
+    out += sprintf(out, "%*ld", width, int_part * signInt_Part);
+
+    // Print the decimal point, but only if there are digits beyond
+    if (prec > 0) {
+        *out = '.';
+        ++out;
+
+
+        for (unsigned char decShift = prec; decShift > 0; decShift--) {
+            remainder *= 10.0;
+        }
+        sprintf(out, "%0*d", prec, (int)remainder);
+    }
+
+    return s;
+}

--- a/cores/arduino/stdlib_noniso.h
+++ b/cores/arduino/stdlib_noniso.h
@@ -1,0 +1,46 @@
+/* 
+  stdlib_noniso.h - nonstandard (but usefull) conversion functions
+  Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+  This file is part of the esp8266 core for Arduino environment.
+ 
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef STDLIB_NONISO_H
+#define STDLIB_NONISO_H
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+int atoi(const char *s);
+
+long atol(const char* s);
+
+double atof(const char* s);
+
+char* itoa (int val, char *s, int radix);
+
+char* ltoa (long val, char *s, int radix);
+
+char* utoa (unsigned int val, char *s, int radix);
+
+char* ultoa (unsigned long val, char *s, int radix);
+ 
+char* dtostrf (double val, signed char width, unsigned char prec, char *s);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif


### PR DESCRIPTION
This patchset ensures that all String examples are compiled and behave like a UNO.
- 64 bit long millis() was not printable
- BIN format was not printable
