### PR TITLE
Jira-334 Update version header location in linker script

### DIFF
--- a/variants/intel_edu_x/linker_scripts/flash.ld
+++ b/variants/intel_edu_x/linker_scripts/flash.ld
@@ -60,12 +60,6 @@ SECTIONS
     {
 /* FLASH Start */
 
-    version_header_section :
-    {
-        *(.version_header)
-        KEEP(*(".version_header*"))
-    } > FLASH
-
     text : ALIGN(1024)
 	{
 	__text_start = .;
@@ -73,6 +67,9 @@ SECTIONS
 /* when !XIP, .text is in RAM, and vector table must be at its very start */
 	KEEP(*(.int_vector_table))
 	KEEP(*(".int_vector_table.*"))
+
+	*(.version_header)
+	KEEP(*(".version_header*"))
 
 	*(.text)
 	*(".text.*")


### PR DESCRIPTION
Need to update linker script to match recent firmware change:

JIRA: FIRE-2160

1024 bytes were used to store the version header, which is only
48 bytes big. So we wasted 976 bytes. By moving it after the vector table,
we can free this 1024 bytes space.
