### PR TITLE
Missing examples folder in Wire library

### DIFF
--- a/libraries/Wire/examples/SFRRanger_reader/SFRRanger_reader.ino
+++ b/libraries/Wire/examples/SFRRanger_reader/SFRRanger_reader.ino
@@ -1,0 +1,87 @@
+// I2C SRF10 or SRF08 Devantech Ultrasonic Ranger Finder
+// by Nicholas Zambetti <http://www.zambetti.com>
+// and James Tichenor <http://www.jamestichenor.net>
+
+// Demonstrates use of the Wire library reading data from the
+// Devantech Utrasonic Rangers SFR08 and SFR10
+
+// Created 29 April 2006
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+void setup()
+{
+  Wire.begin();                // join i2c bus (address optional for master)
+  Serial.begin(9600);          // start serial communication at 9600bps
+}
+
+int reading = 0;
+
+void loop()
+{
+  // step 1: instruct sensor to read echoes
+  Wire.beginTransmission(112); // transmit to device #112 (0x70)
+  // the address specified in the datasheet is 224 (0xE0)
+  // but i2c adressing uses the high 7 bits so it's 112
+  Wire.write(byte(0x00));      // sets register pointer to the command register (0x00)
+  Wire.write(byte(0x50));      // command sensor to measure in "inches" (0x50)
+  // use 0x51 for centimeters
+  // use 0x52 for ping microseconds
+  Wire.endTransmission();      // stop transmitting
+
+  // step 2: wait for readings to happen
+  delay(70);                   // datasheet suggests at least 65 milliseconds
+
+  // step 3: instruct sensor to return a particular echo reading
+  Wire.beginTransmission(112); // transmit to device #112
+  Wire.write(byte(0x02));      // sets register pointer to echo #1 register (0x02)
+  Wire.endTransmission();      // stop transmitting
+
+  // step 4: request reading from sensor
+  Wire.requestFrom(112, 2);    // request 2 bytes from slave device #112
+
+  // step 5: receive reading from sensor
+  if (2 <= Wire.available())   // if two bytes were received
+  {
+    reading = Wire.read();  // receive high byte (overwrites previous reading)
+    reading = reading << 8;    // shift high byte to be high 8 bits
+    reading |= Wire.read(); // receive low byte as lower 8 bits
+    Serial.println(reading);   // print the reading
+  }
+
+  delay(250);                  // wait a bit since people have to read the output :)
+}
+
+
+/*
+
+// The following code changes the address of a Devantech Ultrasonic Range Finder (SRF10 or SRF08)
+// usage: changeAddress(0x70, 0xE6);
+
+void changeAddress(byte oldAddress, byte newAddress)
+{
+  Wire.beginTransmission(oldAddress);
+  Wire.write(byte(0x00));
+  Wire.write(byte(0xA0));
+  Wire.endTransmission();
+
+  Wire.beginTransmission(oldAddress);
+  Wire.write(byte(0x00));
+  Wire.write(byte(0xAA));
+  Wire.endTransmission();
+
+  Wire.beginTransmission(oldAddress);
+  Wire.write(byte(0x00));
+  Wire.write(byte(0xA5));
+  Wire.endTransmission();
+
+  Wire.beginTransmission(oldAddress);
+  Wire.write(byte(0x00));
+  Wire.write(newAddress);
+  Wire.endTransmission();
+}
+
+*/

--- a/libraries/Wire/examples/digital_potentiometer/digital_potentiometer.ino
+++ b/libraries/Wire/examples/digital_potentiometer/digital_potentiometer.ino
@@ -1,0 +1,39 @@
+// I2C Digital Potentiometer
+// by Nicholas Zambetti <http://www.zambetti.com>
+// and Shawn Bonkowski <http://people.interaction-ivrea.it/s.bonkowski/>
+
+// Demonstrates use of the Wire library
+// Controls AD5171 digital potentiometer via I2C/TWI
+
+// Created 31 March 2006
+
+// This example code is in the public domain.
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+void setup()
+{
+  Wire.begin(); // join i2c bus (address optional for master)
+}
+
+byte val = 0;
+
+void loop()
+{
+  Wire.beginTransmission(44); // transmit to device #44 (0x2c)
+  // device address is specified in datasheet
+  Wire.write(byte(0x00));            // sends instruction byte
+  Wire.write(val);             // sends potentiometer value byte
+  Wire.endTransmission();     // stop transmitting
+
+  val++;        // increment value
+  if (val == 64) // if reached 64th position (max)
+  {
+    val = 0;    // start over from lowest value
+  }
+  delay(500);
+}
+

--- a/libraries/Wire/examples/master_reader/master_reader.ino
+++ b/libraries/Wire/examples/master_reader/master_reader.ino
@@ -1,0 +1,34 @@
+// Wire Master Reader
+// by Nicholas Zambetti <http://www.zambetti.com>
+
+// Demonstrates use of the Wire library
+// Reads data from an I2C/TWI slave device
+// Refer to the "Wire Slave Sender" example for use with this
+
+// Created 29 March 2006
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+void setup()
+{
+  Wire.begin();        // join i2c bus (address optional for master)
+  Serial1.begin(9600);  // start serial for output
+}
+
+void loop()
+{
+  Wire.requestFrom(8, 6,false);    // request 6 bytes from slave device #8
+
+  while (Wire.available())   // slave may send less than requested
+  {
+    char c = Wire.read(); // receive a byte as character
+    Serial1.print(c); // print the character
+    Serial1.println();
+    
+  }
+
+  delay(500);
+}

--- a/libraries/Wire/examples/master_writer/master_writer.ino
+++ b/libraries/Wire/examples/master_writer/master_writer.ino
@@ -1,0 +1,34 @@
+// Wire Master Writer
+// by Nicholas Zambetti <http://www.zambetti.com>
+
+// Demonstrates use of the Wire library
+// Writes data to an I2C/TWI slave device
+// Refer to the "Wire Slave Receiver" example for use with this
+
+// Created 29 March 2006
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+
+void setup()
+{
+  Wire.begin(); // join i2c bus (address optional for master)
+  Serial1.begin(9600);
+}
+
+byte x = 1;
+byte rdata;
+void loop()
+{
+  Wire.beginTransmission(8); // transmit to device #8
+  //Wire.write("x is ");        // sends five bytes
+  Wire.write(x);              // sends one byte
+  int result = Wire.endTransmission();    // stop transmitting
+  Serial1.println();
+  Serial1.print("x =  ");
+  Serial1.print(x);
+  x++;
+  delay(500);
+}


### PR DESCRIPTION
- Slave examples not relevant because AtlasPeak does not support
  slave-mode I2C.
- Examples included  digital_potentiometer, master_reader,
  master_writer, SFRRanger_reader.

Signed-off-by: Kevin Moloney kevin.moloney@emutex.com
