### PR TITLE
Specify architecture in library properties

### DIFF
--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -6,4 +6,4 @@ sentence=Enables network connection (local and Internet) using the Arduino Ether
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
 category=Communication
 url=http://www.arduino.cc/en/Reference/Ethernet
-architectures=*
+architectures=arc32

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -5,5 +5,5 @@ maintainer=Paul Stoffregen
 sentence=Access 1-wire temperature sensors, memory and other chips.
 paragraph=
 url=http://www.pjrc.com/teensy/td_libs_OneWire.html
-architectures=*
+architectures=arc32
 

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -6,4 +6,4 @@ sentence=Enables reading and writing on SD cards. For all Arduino boards.
 paragraph=Once an SD memory card is connected to the SPI interfare of the Arduino board you are enabled to create files and read/write on them. You can also move through directories on the SD card.
 category=Data Storage
 url=http://www.arduino.cc/en/Reference/SD
-architectures=*
+architectures=arc32

--- a/libraries/TFT/library.properties
+++ b/libraries/TFT/library.properties
@@ -6,4 +6,4 @@ sentence=Allows drawing text, images, and shapes on the Arduino TFT graphical di
 paragraph=This library is compatible with most of the TFT display based on the ST7735 chipset
 category=Display
 url=http://www.arduino.cc/en/Reference/TFTLibrary
-architectures=*
+architectures=arc32


### PR DESCRIPTION
Avoid conflicts with standard libs by specifying architecture