### PR TITLE
Fix BLE library String handling

### DIFF
--- a/libraries/CurieBle/src/BleCharacteristic.cpp
+++ b/libraries/CurieBle/src/BleCharacteristic.cpp
@@ -201,7 +201,7 @@ BleStatus
 BleCharacteristic::setValue(const String &str)
 {
     str.getBytes((unsigned char *)&_data, (unsigned int)_char_data.max_len, 0U);
-    _data_len = str.len + 1;
+    _data_len = str.length() + 1;
     return _setValue();
 }
 

--- a/libraries/CurieBle/src/BleDescriptor.cpp
+++ b/libraries/CurieBle/src/BleDescriptor.cpp
@@ -93,7 +93,7 @@ BleStatus
 BleDescriptor::setValue(const String &str)
 {
     str.getBytes((unsigned char *)&_data, (unsigned int)BLE_MAX_ATTR_DATA_LEN, 0U);
-    _desc.length = str.len + 1;
+    _desc.length = str.length() + 1;
     return _setValue();
 }
 


### PR DESCRIPTION
The correct way to get a String lenght is by calling String.length()
Now len field is protected so a compilation error will be triggered if accessing the field directly