### PR TITLE
Resolving KW issue with SoftwareSerial destructor

### DIFF
--- a/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/SoftwareSerial.h
@@ -73,7 +73,7 @@ private:
 public:
   // public methods
   SoftwareSerial(uint32_t receivePin, uint32_t transmitPin, bool inverse_logic = false);
-  ~SoftwareSerial();
+  virtual ~SoftwareSerial();
   void begin(long speed);
   bool listen();
   void end();


### PR DESCRIPTION
Class has virtual functions inherited from a base class, but its destructor is not virtual and not empty