### PR TITLE
ATLEDGE-396 Fix behavior of analogWrite() on non PWM pins

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -51,7 +51,18 @@ static inline uint32_t mapResolution(uint32_t value, uint32_t from, uint32_t to)
 
 void analogWrite(uint8_t pin, int val)
 {
-    if (! digitalPinHasPWM(pin)) return;
+    if (! digitalPinHasPWM(pin))
+    {
+        if(val > 127)
+        {
+            digitalWrite(pin, HIGH);
+        }
+        else
+        {
+            digitalWrite(pin, LOW);
+        }
+        return;
+    }
 
     if (val <= 0) {
         /* Use GPIO for 0% duty cycle (always off)  */


### PR DESCRIPTION
For all non PWM pins, the behavior of calling analogWrite() should be
logic 0 if the value is 127 or less. For values of 128 or above, the pin
should go to logic 1.