### PR TITLE
Add error message if using IDE 1.6.6

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -29,6 +29,10 @@
 #include "binary.h"
 //#include "itoa.h"
 
+#if ARDUINO == 10606
+#error IDE version incompatible with Arduino 101, please upgrade to it to version 1.6.7 or newer
+#endif
+
 #ifdef __cplusplus
 extern "C"{
 #endif // __cplusplus


### PR DESCRIPTION
`arduino-builder` creates buggy binaries on 1.6.6 only, so check if we are using that version and break the compilation.
Nightly versions are already tagged 1.6.7 so they are safe to use (also 1.6.5 is safe, too)