### PR TITLE
CurieRTC - SetTime example not setting RTC

### DIFF
--- a/libraries/CurieRTC/examples/SetTime/SetTime.ino
+++ b/libraries/CurieRTC/examples/SetTime/SetTime.ino
@@ -16,7 +16,7 @@ void setup() {
   // get the date and time the compiler was run
   if (getDate(__DATE__) && getTime(__TIME__)) {
     t = makeTime(tm);
-    setTime(t);
+    RTC.set(t);
     parse = true;
     config = true;
   }


### PR DESCRIPTION
RTC not being set because the wrong call was being made should call
RTC.set(t) to set the hardware RTC instead of setTime(t).