### PR TITLE
ATLEDGE-426/ATLEDGE-445 CurieImu missing functions

### DIFF
--- a/libraries/CurieImu/src/BMI160.cpp
+++ b/libraries/CurieImu/src/BMI160.cpp
@@ -807,6 +807,35 @@ void BMI160Class::setShockDetectionDuration(uint8_t duration) {
     reg_write(BMI160_RA_INT_LOWHIGH_3, duration);
 }
 
+/** Get Step Detection mode.
+ * Returns an enum value which corresponds to current mode
+ * 0 = Normal Mode
+ * 1 = Sensitive Mode
+ * 2 = Robust Mode
+ * 3 = Unkown Mode
+ * For more details on the Step Detection, see Section
+ * 2.11.37 of the BMI160 Data Sheet.
+ *
+ * @return Current configuration of the step detector
+ * @see BMI160_RA_STEP_CONF_0
+ * @see BMI160_RA_STEP_CONF_1
+ */
+uint8_t BMI160Class::getStepDetectionMode() {
+    uint8_t ret_step_conf0, ret_min_step_buf;
+
+    ret_step_conf0 = reg_read(BMI160_RA_STEP_CONF_0);
+    ret_min_step_buf = reg_read(BMI160_RA_STEP_CONF_1);
+
+    if ((ret_step_conf0 == BMI160_RA_STEP_CONF_0_NOR) && (ret_min_step_buf == BMI160_RA_STEP_CONF_1_NOR))
+        return BMI160_STEP_MODE_NORMAL;
+    else if ((ret_step_conf0 == BMI160_RA_STEP_CONF_0_SEN) && (ret_min_step_buf == BMI160_RA_STEP_CONF_1_SEN))
+	return BMI160_STEP_MODE_SENSITIVE;
+    else if ((ret_step_conf0 == BMI160_RA_STEP_CONF_0_ROB) && (ret_min_step_buf == BMI160_RA_STEP_CONF_1_ROB))
+        return BMI160_STEP_MODE_ROBUST;
+    else
+        return BMI160_STEP_MODE_UNKNOWN;
+}
+
 /** Set Step Detection mode.
  * Sets the step detection mode to one of 3 predefined sensitivity settings:
  *
@@ -849,6 +878,7 @@ void BMI160Class::setStepDetectionMode(BMI160StepMode mode) {
                    BMI160_STEP_BUF_MIN_BIT,
                    BMI160_STEP_BUF_MIN_LEN);
 }
+
 
 /** Get Step Counter enabled status.
  * Once enabled and configured correctly (@see setStepDetectionMode()), the

--- a/libraries/CurieImu/src/BMI160.h
+++ b/libraries/CurieImu/src/BMI160.h
@@ -231,6 +231,14 @@ THE SOFTWARE.
 #define BMI160_RA_STEP_CONF_0       0x7A
 #define BMI160_RA_STEP_CONF_1       0x7B
 
+#define BMI160_RA_STEP_CONF_0_NOR   0x15
+#define BMI160_RA_STEP_CONF_0_SEN   0x2D
+#define BMI160_RA_STEP_CONF_0_ROB   0x1D
+#define BMI160_RA_STEP_CONF_1_NOR   0x03
+#define BMI160_RA_STEP_CONF_1_SEN   0x00
+#define BMI160_RA_STEP_CONF_1_ROB   0x07
+
+
 #define BMI160_GYRO_RANGE_SEL_BIT   0
 #define BMI160_GYRO_RANGE_SEL_LEN   3
 
@@ -351,6 +359,7 @@ typedef enum {
     BMI160_STEP_MODE_NORMAL = 0,
     BMI160_STEP_MODE_SENSITIVE,
     BMI160_STEP_MODE_ROBUST,
+    BMI160_STEP_MODE_UNKNOWN,
 } BMI160StepMode;
 
 /**
@@ -539,6 +548,7 @@ class BMI160Class {
         uint8_t getDoubleTapDetectionDuration();
         void setDoubleTapDetectionDuration(uint8_t duration);
 
+        uint8_t getStepDetectionMode();
         void setStepDetectionMode(BMI160StepMode mode);
         bool getStepCountEnabled();
         void setStepCountEnabled(bool enabled);
@@ -603,7 +613,6 @@ class BMI160Class {
         bool getYPosShockDetected();
         bool getZNegShockDetected();
         bool getZPosShockDetected();
-        bool getZeroShockDetected();
 
         bool getXNegMotionDetected();
         bool getXPosMotionDetected();
@@ -611,7 +620,6 @@ class BMI160Class {
         bool getYPosMotionDetected();
         bool getZNegMotionDetected();
         bool getZPosMotionDetected();
-        bool getZeroMotionDetected();
 
         bool getXNegTapDetected();
         bool getXPosTapDetected();


### PR DESCRIPTION
* Removed CurieImu.getZeroShockDetected() & CurieImu.getZeroMotionDetected().
* Functions were replaced with CurieImu.getIntShockStatus() & CurieImu.getIntZeroMotionStatus().

* Implemented getStepDetectionMode().
* There was no means of verifying setStepDetectionMode().

Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>