### PR TITLE
hardcode sketchUploader version

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -89,16 +89,16 @@ recipe.size.regex=Total\s+([0-9]+).*
 
 # Arc Uploader/Programmers tools
 # -------------------
-tools.arduino101load.cmd.path={runtime.tools.sketchUploader.path}/clupload/cluploadArduino101_osx.sh
-tools.arduino101load.cmd.path.linux="{runtime.tools.sketchUploader.path}/clupload/cluploadArduino101_linux.sh"
-tools.arduino101load.cmd.path.windows={runtime.tools.sketchUploader.path}/x86/bin/bash.exe
-tools.arduino101load.cmd.script.windows={runtime.tools.sketchUploader.path}/clupload/cluploadArduino101_win.sh
-tools.arduino101load.cmd.bin.windows={runtime.tools.sketchUploader.path}/x86/bin
+tools.arduino101load.cmd.path={runtime.tools.sketchUploader-1.6.4+1.14.path}/clupload/cluploadArduino101_osx.sh
+tools.arduino101load.cmd.path.linux="{runtime.tools.sketchUploader-1.6.4+1.14.path}/clupload/cluploadArduino101_linux.sh"
+tools.arduino101load.cmd.path.windows={runtime.tools.sketchUploader-1.6.4+1.14.path}/x86/bin/bash.exe
+tools.arduino101load.cmd.script.windows={runtime.tools.sketchUploader-1.6.4+1.14.path}/clupload/cluploadArduino101_win.sh
+tools.arduino101load.cmd.bin.windows={runtime.tools.sketchUploader-1.6.4+1.14.path}/x86/bin
 
 tools.arduino101load.upload.params.verbose=verbose
 tools.arduino101load.upload.params.quiet=quiet
 
-tools.arduino101load.upload.pattern=/bin/bash --noprofile "{cmd.path}" "{runtime.tools.sketchUploader.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
-tools.arduino101load.upload.pattern.linux=/bin/bash --noprofile {cmd.path} "{runtime.tools.sketchUploader.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
+tools.arduino101load.upload.pattern=/bin/bash --noprofile "{cmd.path}" "{runtime.tools.sketchUploader-1.6.4+1.14.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
+tools.arduino101load.upload.pattern.linux=/bin/bash --noprofile {cmd.path} "{runtime.tools.sketchUploader-1.6.4+1.14.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
 tools.arduino101load.upload.elf.windows={build.path}/{build.project_name}.elf
 tools.arduino101load.upload.pattern.windows="{cmd.path}" "--noprofile" "{cmd.script}" "{cmd.bin}" "{upload.elf}" "{serial.port}" "{upload.verbose}"


### PR DESCRIPTION
while we solve the bug IDE-side, it is safe to revert using the hardcoded version number to handle the sketchUploader installation;
This solves a clash with outdeted Galileo/Edison core which tools are picked randomly (depending on json download order and java filesystem library internal ordering).

@calvinatintel 