### PR TITLE
Unique library.properties names

### DIFF
--- a/libraries/Adafruit_DotStar/library.properties
+++ b/libraries/Adafruit_DotStar/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit DotStar
+name=Adafruit DotStar(Arduino 101)
 version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>

--- a/libraries/Adafruit_Motor_Shield_V2_Library/library.properties
+++ b/libraries/Adafruit_Motor_Shield_V2_Library/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit Motor Shield V2 Library
+name=Adafruit Motor Shield V2 Library(Arduino 101)
 version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>

--- a/libraries/Adafruit_NeoPixel/library.properties
+++ b/libraries/Adafruit_NeoPixel/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit NeoPixel
+name=Adafruit NeoPixel(Arduino 101)
 version=1.0.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet(Arduino 101)
 version=1.0.4
 author=Arduino
 maintainer=Arduino <info@arduino.cc>

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,4 +1,4 @@
-name=OneWire
+name=OneWire(Arduino 101)
 version=2.3
 author=Jim Studt, Tom Pollard, Robin James, Glenn Trewitt, Jason Dangel, Guillermo Lovato, Paul Stoffregen, Scott Roberts, Bertrik Sikken, Mark Tillotson, Ken Butcher, Roger Clark, Love Nystrom
 maintainer=Paul Stoffregen

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD(Arduino 101)
 version=1.0.6
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo(Arduino 101)
 version=1.0
 author=Intel/Emutex
 maintainer=Intel/Emutex <kevin@emutex.com>

--- a/libraries/TFT/library.properties
+++ b/libraries/TFT/library.properties
@@ -1,4 +1,4 @@
-name=TFT
+name=TFT(Arduino 101)
 version=1.0.4
 author=Arduino, Adafruit
 maintainer=Arduino <info@arduino.cc>


### PR DESCRIPTION
Change `name` value in library.properties to unique values for all libraries that are in the Library Manager index.
- Prevents incorrect updatable library notifications(Arduino IDE 1.6.6 and up).
- Fixes the problem of Arduino IDE built in libraries always showing as Type: updatable in Library Manager when the Arduino IDE built in library version number is higher than the Arduino 101 library version number.

Similar changes have already been made to Galileo and Edison corelibs: https://github.com/01org/corelibs-galileo/pull/16, https://github.com/01org/corelibs-galileo/pull/18, https://github.com/01org/corelibs-edison/commit/09ec7d13621b466dcd318aa8d6e24e2f23ed5f5b