### PR TITLE
[DO NOT MERGE YET] Use unified upload tool

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -89,16 +89,9 @@ recipe.size.regex=Total\s+([0-9]+).*
 
 # Arc Uploader/Programmers tools
 # -------------------
-tools.arduino101load.cmd.path={runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_osx.sh
-tools.arduino101load.cmd.path.linux="{runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_linux.sh"
-tools.arduino101load.cmd.path.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin/bash.exe
-tools.arduino101load.cmd.script.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_win.sh
-tools.arduino101load.cmd.bin.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin
+tools.arduino101load.cmd.path={runtime.tools.arduino101load.path}/arduino101load
 
 tools.arduino101load.upload.params.verbose=verbose
 tools.arduino101load.upload.params.quiet=quiet
 
-tools.arduino101load.upload.pattern=/bin/bash --noprofile "{cmd.path}" "{runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
-tools.arduino101load.upload.pattern.linux=/bin/bash --noprofile {cmd.path} "{runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
-tools.arduino101load.upload.elf.windows={build.path}/{build.project_name}.elf
-tools.arduino101load.upload.pattern.windows="{cmd.path}" "--noprofile" "{cmd.script}" "{cmd.bin}" "{upload.elf}" "{serial.port}" "{upload.verbose}"
+tools.arduino101load.upload.pattern="{cmd.path}" "{runtime.tools.arduino101load.path}/x86/bin" {build.path}/{build.project_name}.bin {serial.port} "{upload.verbose}"


### PR DESCRIPTION
By replacing existing `bash` + script procedure (very OS-specific and error prone) with this tool (https://github.com/facchinm/arduino101load) the flasher commandline generation can be greatly simplified.
This would also help separation between legacy `sketchUploader` and dfu-based uploader for 101