### PR TITLE
ATLEDGE-491 - rename sketchUploader tool to arduino101load

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -89,16 +89,16 @@ recipe.size.regex=Total\s+([0-9]+).*
 
 # Arc Uploader/Programmers tools
 # -------------------
-tools.arduino101load.cmd.path={runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_osx.sh
-tools.arduino101load.cmd.path.linux="{runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_linux.sh"
-tools.arduino101load.cmd.path.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin/bash.exe
-tools.arduino101load.cmd.script.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/clupload/cluploadArduino101_win.sh
-tools.arduino101load.cmd.bin.windows={runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin
+tools.arduino101load.cmd.path={runtime.tools.arduino101load.path}/clupload/cluploadArduino101_osx.sh
+tools.arduino101load.cmd.path.linux="{runtime.tools.arduino101load.path}/clupload/cluploadArduino101_linux.sh"
+tools.arduino101load.cmd.path.windows={runtime.tools.arduino101load.path}/x86/bin/bash.exe
+tools.arduino101load.cmd.script.windows={runtime.tools.arduino101load.path}/clupload/cluploadArduino101_win.sh
+tools.arduino101load.cmd.bin.windows={runtime.tools.arduino101load.path}/x86/bin
 
 tools.arduino101load.upload.params.verbose=verbose
 tools.arduino101load.upload.params.quiet=quiet
 
-tools.arduino101load.upload.pattern=/bin/bash --noprofile "{cmd.path}" "{runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
-tools.arduino101load.upload.pattern.linux=/bin/bash --noprofile {cmd.path} "{runtime.tools.sketchUploader-1.6.4+1.15.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
+tools.arduino101load.upload.pattern=/bin/bash --noprofile "{cmd.path}" "{runtime.tools.arduino101load.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
+tools.arduino101load.upload.pattern.linux=/bin/bash --noprofile {cmd.path} "{runtime.tools.arduino101load.path}/x86/bin" {build.path}/{build.project_name}.elf {serial.port} "{upload.verbose}"
 tools.arduino101load.upload.elf.windows={build.path}/{build.project_name}.elf
 tools.arduino101load.upload.pattern.windows="{cmd.path}" "--noprofile" "{cmd.script}" "{cmd.bin}" "{upload.elf}" "{serial.port}" "{upload.verbose}"


### PR DESCRIPTION
Renaming sketchUploader tool to arduino101load to avoid conflict in IDE if Galileo/Edison is installed