### PR TITLE
Jira-501: CurieTimer.resume() did not re-enable interrupt at the controller.

### DIFF
--- a/libraries/CurieTimerOne/CurieTimer.cpp
+++ b/libraries/CurieTimerOne/CurieTimer.cpp
@@ -139,6 +139,9 @@ void CurieTimer::resume(void)
   aux_reg_write(timerCountAddr, pauseCount);
   aux_reg_write(timerControlAddr, pauseCntrl);
   currState = RUNNING;
+
+  // Re-enable timer interrupt once timer is reloaded with previous stop values.
+  interrupt_enable(timerIrqNum);
 }
 
 


### PR DESCRIPTION
CureTimerOne library:  Routine resume() did not re-enable interrupt upon exit - bug.  Corrected.