### PR TITLE
Add setConnectionInterval API to CurieBle

### DIFF
--- a/libraries/CurieBle/keywords.txt
+++ b/libraries/CurieBle/keywords.txt
@@ -52,6 +52,7 @@ begin	KEYWORD2
 setAdvertisedServiceUuid	KEYWORD2
 setLocalName	KEYWORD2
 setAppearance	KEYWORD2
+setConnectionInterval	KEYWORD2
 addAttribute	KEYWORD2
 central	KEYWORD2
 

--- a/libraries/CurieBle/src/BLEPeripheral.cpp
+++ b/libraries/CurieBle/src/BLEPeripheral.cpp
@@ -48,6 +48,8 @@ BLEPeripheral::BLEPeripheral(void) :
     _advertise_service_uuid(NULL),
     _local_name(NULL),
     _appearance(0),
+    _min_conn_interval(DEFAULT_MIN_CONN_INTERVAL),
+    _max_conn_interval(DEFAULT_MAX_CONN_INTERVAL),
     _central(this),
     _attributes(NULL),
     _num_attributes(0),
@@ -165,6 +167,25 @@ BLEPeripheral::setAppearance(const uint16_t appearance)
 }
 
 void
+BLEPeripheral::setConnectionInterval(const unsigned short minConnInterval, const unsigned short maxConnInterval)
+{
+    _min_conn_interval = minConnInterval;
+    _max_conn_interval = maxConnInterval;
+
+    if (_min_conn_interval < MIN_CONN_INTERVAL) {
+        _min_conn_interval = MIN_CONN_INTERVAL;
+    } else if (_min_conn_interval > MAX_CONN_INTERVAL) {
+        _min_conn_interval = MAX_CONN_INTERVAL;
+    }
+
+    if (_max_conn_interval < _min_conn_interval) {
+        _max_conn_interval = _min_conn_interval;
+    } else if (_max_conn_interval > MAX_CONN_INTERVAL) {
+        _max_conn_interval = MAX_CONN_INTERVAL;
+    }
+}
+
+void
 BLEPeripheral::setEventHandler(BLEPeripheralEvent event, BLEPeripheralEventHandler callback)
 {
   if (event < sizeof(_event_handlers)) {
@@ -244,7 +265,7 @@ BLEPeripheral::_init()
         return status;
     }
 
-    status = ble_client_gap_set_enable_config(_device_name, &_local_bda, _appearance, txPower);
+    status = ble_client_gap_set_enable_config(_device_name, &_local_bda, _appearance, txPower, _min_conn_interval, _max_conn_interval);
     if (BLE_STATUS_SUCCESS != status) {
         return status;
     }

--- a/libraries/CurieBle/src/BLEPeripheral.h
+++ b/libraries/CurieBle/src/BLEPeripheral.h
@@ -101,6 +101,16 @@ public:
     void setAppearance(const unsigned short appearance);
 
     /**
+     * Set the min and max connection interval BLE Peripheral Device
+     *
+     * @param minConnInterval Minimum connection interval (1.25 ms units), minimum 0x0006 (7.5ms)
+     * @param maxConnInterval Maximum connection interval (1.25 ms units), maximum 0x095f (2998.75ms)
+     *
+     * @note This method must be called before the begin method
+     */
+    void setConnectionInterval(const unsigned short minConnInterval, const unsigned short maxConnInterval);
+
+    /**
      * Add an attribute to the BLE Peripheral Device
      *
      * @param attribute Attribute to add to Peripheral
@@ -186,6 +196,8 @@ private:
     const char* _local_name;
     char       _device_name[BLE_MAX_DEVICE_NAME+1];
     uint16_t   _appearance;
+    uint16_t   _min_conn_interval;
+    uint16_t   _max_conn_interval;
     uint8_t    _adv_data[BLE_MAX_ADV_SIZE];
     uint8_t    _adv_data_len;
     ble_addr_t _local_bda;

--- a/libraries/CurieBle/src/internal/ble_client.c
+++ b/libraries/CurieBle/src/internal/ble_client.c
@@ -48,20 +48,6 @@
 #include "ble_client.h"
 #include "platform.h"
 
-enum {
-    UNIT_0_625_MS = 625,                            /**< Number of microseconds in 0.625 milliseconds. */
-    UNIT_1_25_MS = 1250,                            /**< Number of microseconds in 1.25 milliseconds. */
-    UNIT_10_MS = 10000                              /**< Number of microseconds in 10 milliseconds. */
-};
-
-#define MSEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000) / (RESOLUTION))
-
-/* Connection parameters used for Peripheral Preferred Connection Parameterss (PPCP) and update request */
-#define MIN_CONN_INTERVAL MSEC_TO_UNITS(80, UNIT_1_25_MS)
-#define MAX_CONN_INTERVAL MSEC_TO_UNITS(150, UNIT_1_25_MS)
-#define SLAVE_LATENCY 0
-#define CONN_SUP_TIMEOUT MSEC_TO_UNITS(6000, UNIT_10_MS)
-
 /* Advertising parameters */
 #define BLE_GAP_ADV_TYPE_ADV_IND          0x00   /**< Connectable undirected. */
 #define BLE_GAP_ADV_FP_ANY                0x00   /**< Allow scan requests and connect requests from any device. */
@@ -496,7 +482,9 @@ BleStatus ble_client_init(ble_client_gap_event_cb_t gap_event_cb, void *gap_even
 BleStatus ble_client_gap_set_enable_config(const char *name,
                                            const ble_addr_t *bda,
                                            const uint16_t appearance,
-                                           const int8_t tx_power)
+                                           const int8_t tx_power,
+                                           const uint16_t min_conn_interval,
+                                           const uint16_t max_conn_interval)
 {
     struct ble_wr_config config;
     BleStatus status;
@@ -505,12 +493,12 @@ BleStatus ble_client_gap_set_enable_config(const char *name,
     config.p_name = (uint8_t *)name;
     config.appearance = appearance;
     config.tx_power = tx_power;
-    config.peripheral_conn_params.interval_min = MIN_CONN_INTERVAL;
-    config.peripheral_conn_params.interval_max = MAX_CONN_INTERVAL;
+    config.peripheral_conn_params.interval_min = min_conn_interval;
+    config.peripheral_conn_params.interval_max = max_conn_interval;
     config.peripheral_conn_params.slave_latency = SLAVE_LATENCY;
     config.peripheral_conn_params.link_sup_to = CONN_SUP_TIMEOUT;
-    config.central_conn_params.interval_min = MIN_CONN_INTERVAL;
-    config.central_conn_params.interval_max = MAX_CONN_INTERVAL;
+    config.central_conn_params.interval_min = min_conn_interval;
+    config.central_conn_params.interval_max = max_conn_interval;
     config.central_conn_params.slave_latency = SLAVE_LATENCY;
     config.central_conn_params.link_sup_to = CONN_SUP_TIMEOUT;
 

--- a/libraries/CurieBle/src/internal/ble_client.h
+++ b/libraries/CurieBle/src/internal/ble_client.h
@@ -33,6 +33,22 @@
 
 #include "BLECommon.h"
 
+enum {
+    UNIT_0_625_MS = 625,                            /**< Number of microseconds in 0.625 milliseconds. */
+    UNIT_1_25_MS = 1250,                            /**< Number of microseconds in 1.25 milliseconds. */
+    UNIT_10_MS = 10000                              /**< Number of microseconds in 10 milliseconds. */
+};
+
+#define MSEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000) / (RESOLUTION))
+
+/* Connection parameters used for Peripheral Preferred Connection Parameterss (PPCP) and update request */
+#define DEFAULT_MIN_CONN_INTERVAL MSEC_TO_UNITS(80, UNIT_1_25_MS)
+#define DEFAULT_MAX_CONN_INTERVAL MSEC_TO_UNITS(150, UNIT_1_25_MS)
+#define MIN_CONN_INTERVAL 0x0006
+#define MAX_CONN_INTERVAL 0x095f
+#define SLAVE_LATENCY 0
+#define CONN_SUP_TIMEOUT MSEC_TO_UNITS(6000, UNIT_10_MS)
+
 /* Borrowed from ble_service_utils.h */
 #define UINT8_TO_LESTREAM(p, i) \
     do { *(p)++ = (uint8_t)(i); } \
@@ -98,7 +114,9 @@ BleStatus ble_client_init(ble_client_gap_event_cb_t gap_event_cb,
 BleStatus ble_client_gap_set_enable_config(const char *name,
                                            const ble_addr_t *bda,
                                            const uint16_t appearance,
-                                           const int8_t tx_power);
+                                           const int8_t tx_power,
+                                           const uint16_t min_conn_interval,
+                                           const uint16_t max_conn_interval);
 BleStatus ble_client_gap_get_bda(ble_addr_t *p_bda);
 BleStatus ble_client_gap_wr_adv_data(uint8_t *adv_data,
                                      const uint8_t adv_data_len);


### PR DESCRIPTION
As requested and discussed in #95.

**Note:** A maximum of 4s (0x0c80) did not work, after some testing 2998.75ms (0x095f) is the maximum connection interval that is accepted by the lower level BLE API's.

cc/ @soundanalogous @monteslu