### PR TITLE
Fix issues in CurieTimerOne

### DIFF
--- a/libraries/CurieTimerOne/CurieTimer.cpp
+++ b/libraries/CurieTimerOne/CurieTimer.cpp
@@ -163,6 +163,8 @@ int CurieTimer::pwmStart(unsigned int outputPin, double dutyPercentage, unsigned
   pinMode(pwmPin, OUTPUT);
 
   if(dutyPercentage == 0.0) {
+    // If PWM is already running, reset the timer and set pin to LOW
+    kill(); 
     digitalWrite(pwmPin, LOW);
     return SUCCESS;
   }

--- a/libraries/CurieTimerOne/keywords.txt
+++ b/libraries/CurieTimerOne/keywords.txt
@@ -21,7 +21,7 @@ rdRstTickCount	KEYWORD2
 pause		KEYWORD2
 resume		KEYWORD2
 pwmStart	KEYWORD2
-pwdStop		KEYWORD2
+pwmStop		KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
* Fix pwmStop recognition in keywords.txt
* ATLEDGE-516 PWM does not stop using 0% duty cycle