### PR TITLE
Stop interrupt when switching to 100% duty cycle

### DIFF
--- a/libraries/CurieTimerOne/CurieTimer.cpp
+++ b/libraries/CurieTimerOne/CurieTimer.cpp
@@ -170,6 +170,8 @@ int CurieTimer::pwmStart(unsigned int outputPin, double dutyPercentage, unsigned
   }
 
   if(dutyPercentage == 100.0) {
+    // If PWM is already running, reset the timer and set pin to HIGH
+    kill(); 
     digitalWrite(pwmPin, HIGH);
     return SUCCESS;
   }


### PR DESCRIPTION
This fix is similar to the 0% duty-cycle fix. The interrupt was not being stopped for 100% duty-cycle condition.