### PR TITLE
Fixing sketch size calculation (text + ctors + rodata)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -11,6 +11,7 @@ arduino_101.vid.0x2A03.warning=Uncertified
 arduino_101.upload.tool=arduino101load
 arduino_101.upload.protocol=script
 arduino_101.upload.maximum_size=196608
+arduino_101.upload.maximum_data_size=8192
 arduino_101.upload.use_1200bps_touch=true
 arduino_101.upload.wait_for_upload_port=false
 arduino_101.upload.native_usb=false

--- a/platform.txt
+++ b/platform.txt
@@ -85,7 +85,8 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=Total\s+([0-9]+).*
+recipe.size.regex=^(?:text|ctors|rodata)\s+([0-9]+).*
+recipe.size.regex.data=^(?:datas|bss)\s+([0-9]+).*
 
 # Arc Uploader/Programmers tools
 # -------------------


### PR DESCRIPTION
Change the total sketch size calculation based on Sidney's explanation:

> The arc-elf32-size.exe added in other sections to the total Sketch flash usage and that is not correct.  The calculation should be the sum of text, ctor, and rodata sections.  Need to correct the upload script to reflect that.