### PR TITLE
i2c bus scan workaround

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -110,11 +110,9 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 		if (txBufferLength >= 1) {
 			err = i2c_writebytes(txBuffer, txBufferLength, !sendStop);
 		} else {
-			/* FIXME: A zero byte transmit is typically used to check for an
-			 * ACK from the slave device. This is currently not supported by
-			 * this library implementation
-			 */
-			return 4; // Other error
+            //Workaround: I2C bus scan is currently implemented by sending an extra byte of value 0
+            txBuffer[0] = 0;
+            err = i2c_writebytes(txBuffer, 1, !sendStop);
 		}
 		// empty buffer
 		txBufferLength = 0;


### PR DESCRIPTION
-sends a byte of value 0 when doing an i2c bus scan