### PR TITLE
README.md: Add note to specify that no other folders can be present i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ If you wish to use the latest **untested** changes, follow these instructions.
   * OS X: `~/Library/Arduino15`
   * Linux: `~/.arduino15`
 5. Go to `packages/Intel/hardware/arc32/<version>/`
-6. Delete the content of the directory from step 5, and replace it with the content of the "corelibs-arduino101-master" folder in the zip from step 2.
+6. Delete the content of the directory from step 5, and replace it with the content of the "corelibs-arduino101-master" folder in the zip from step 2. Make sure to not have any other folders in `packages/Intel/hardware/arc32/`.
 
 Future upgrades may fail since the internal contents were modified by hand. In order to recover, shut down the IDE, delete the entire `Arduino15` directory, then restart the IDE.


### PR DESCRIPTION
…n arc32

Having another folder causes a compilation error with an unknown board error.

Fixes #130

Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>