### PR TITLE
Jira-528.  Make CurieTimerOne library to be compatible with the Timer…

### DIFF
--- a/libraries/CurieTimerOne/examples/CurieTimer1BlinkSpeed/blinkSpeed.ino
+++ b/libraries/CurieTimerOne/examples/CurieTimer1BlinkSpeed/blinkSpeed.ino
@@ -1,0 +1,30 @@
+#include <CurieTimerOne.h>
+
+const int blinkPin = 13;
+
+void setup(void)
+{
+  CurieTimerOne.initialize(50000);
+  Serial.begin(9600);
+}
+
+void loop(void)
+{
+  unsigned int range;
+
+  Serial.println("PWM blink: low -> high duty cycle");
+
+  for (float dutyCycle = 5.0; dutyCycle <= 100.0; dutyCycle++) {
+    range = (dutyCycle / 100) * 1023;
+    CurieTimerOne.pwm(blinkPin, range);
+    delay(50);
+  }
+
+  Serial.println("PWM blink: high -> low duty cycle");
+
+  for (float dutyCycle = 100.0; dutyCycle > 5.0; dutyCycle--) {
+    range = (dutyCycle / 100) * 1023;
+    CurieTimerOne.setPwmDuty(blinkPin, range);
+    delay(50);
+  }
+}

--- a/libraries/CurieTimerOne/keywords.txt
+++ b/libraries/CurieTimerOne/keywords.txt
@@ -11,18 +11,24 @@ CurieTimer KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-start	KEYWORD2
-restart	KEYWORD2
-kill	KEYWORD2
-attachInterrupt	KEYWORD2
-detachInterrupt	KEYWORD2
-readTickCount	KEYWORD2
-rdRstTickCount	KEYWORD2
-pause		KEYWORD2
-resume		KEYWORD2
-pwmStart	KEYWORD2
-pwmStop		KEYWORD2
+initialize      KEYWORD2
+setPeriod       KEYWORD2
+start           KEYWORD2
+stop            KEYWORD2
+restart         KEYWORD2
+resume          KEYWORD2
+setPwmDuty      KEYWORD2
+pwm             KEYWORD2
+disablePwm      KEYWORD2
+attachInterrupt KEYWORD2
+detachInterrupt KEYWORD2
+kill            KEYWORD2
+readTickCount   KEYWORD2
+rdRstTickCount  KEYWORD2
+pause           KEYWORD2
+pwmStart        KEYWORD2
+pwmStop         KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################
-CurieTimerOne	KEYWORD2
+CurieTimerOne   KEYWORD2


### PR DESCRIPTION
…One library originated from Paul.  Created methods that have the same name and functionalities as in the TimerOne library.

Added an example Sketch that uses the original TimerOne methods.
