### PR TITLE
Jira-575, Jira-506:  Bug fixes to print float and double correctly, i…

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -289,18 +289,29 @@ size_t Print::printLongLong(unsigned long long n, uint8_t base) {
 size_t Print::printFloat(double number, uint8_t digits)
 {
   size_t n = 0;
+  int exponent = 0;
+  double tmp;
 
   if (isnan(number)) return print("nan");
   if (isinf(number)) return print("inf");
-  if (number > 4294967040.0) return print ("ovf");  // constant determined empirically
-  if (number <-4294967040.0) return print ("ovf");  // constant determined empirically
 
   // Handle negative numbers
-  if (number < 0.0)
-  {
-     n += print('-');
-     number = -number;
+  if (number < 0.0) {
+    n += print('-');
+    number = -number;
   }
+
+  // Chk if integer part has more than 8 digits.
+  tmp = number;
+  while (true) {
+    tmp /= 10.0;
+    exponent++;
+    if (tmp < 10.0)  break;
+  }
+  if (exponent > 8)
+    number = tmp;
+  else
+    exponent = 0;
 
   // Round correctly so that print(1.999, 2) prints as "2.00"
   double rounding = 0.5;
@@ -326,6 +337,12 @@ size_t Print::printFloat(double number, uint8_t digits)
     int toPrint = int(remainder);
     n += print(toPrint);
     remainder -= toPrint;
+  }
+
+  // Print the exponent portion
+  if (exponent) {
+    n += print("e+");
+    n += print(exponent);
   }
 
   return n;

--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -135,14 +135,14 @@ String::String(float value, unsigned char decimalPlaces)
 {
 	init();
 	char buf[33];
-	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+	*this = dtostrf(value, (33 - 1), decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces)
 {
 	init();
 	char buf[33];
-	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+	*this = dtostrf(value, (33 - 1), decimalPlaces, buf);
 }
 
 String::~String()
@@ -363,14 +363,14 @@ unsigned char String::concat(unsigned long long num)
 unsigned char String::concat(float num)
 {
 	char buf[20];
-	char* string = dtostrf(num, 4, 2, buf);
+	char* string = dtostrf(num, (20 - 1), 2, buf);
 	return concat(string, strlen(string));
 }
 
 unsigned char String::concat(double num)
 {
 	char buf[20];
-	char* string = dtostrf(num, 4, 2, buf);
+	char* string = dtostrf(num, (20 - 1), 2, buf);
 	return concat(string, strlen(string));
 }
 

--- a/cores/arduino/stdlib_noniso.h
+++ b/cores/arduino/stdlib_noniso.h
@@ -37,7 +37,7 @@ char* utoa (unsigned int val, char *s, int radix);
 
 char* ultoa (unsigned long val, char *s, int radix);
  
-char* dtostrf (double val, signed char width, unsigned char prec, char *s);
+char* dtostrf (double val, unsigned char width, unsigned char prec, char *s);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
…n a string or std output.

With latest toolChain, the printing of float and double would result in an overfloat condition if the value is bigger than 8 digits.  The String construction would hang the code.  The fix put it will print out a large float/double in the exponent format of, x.xxe+yyy, if the value has more than 8 digits.

@calvinatintel @bigdinotech @kmsywula   Please review my changes.