### PR TITLE
JIRA-578 pwmStop() leaves pin HIGH

### DIFF
--- a/libraries/CurieTimerOne/src/CurieTimerOne.cpp
+++ b/libraries/CurieTimerOne/src/CurieTimerOne.cpp
@@ -76,7 +76,7 @@ void CurieTimer::kill()
   tickCnt = 0;
   userCB = NULL;
   currState = IDLE;
-  pauseCntrl = pauseCount = pwmPin = dutyCycle = nonDutyCycle = periodInUsec = 0;
+  pauseCntrl = pauseCount = dutyCycle = nonDutyCycle = periodInUsec = 0;
 }
 
 


### PR DESCRIPTION
CurieTimerOne::pwmStop() was doing a digitalWrite(pwmPin, LOW) after the kill() so unless the pin happened to be 0 the pwmPin might be left in the HIGH state causing motors or other devices to run HIGH after pwmStop(). Just removed the pwmPin = 0 from kill() and it passes all our loopback tests.