### PR TITLE
I2C - add functionality to change i2c clock speed

### DIFF
--- a/cores/arduino/i2c.c
+++ b/cores/arduino/i2c.c
@@ -103,7 +103,7 @@ int i2c_openadapter(void)
 {
 	int ret;
 
-	SET_PIN_MODE(24, I2C_MUX_MODE); // Rdx SOC PIN (Arduino header pin 18)
+	SET_PIN_MODE(24, I2C_MUX_MODE); // Rxd SOC PIN (Arduino header pin 18)
 	SET_PIN_MODE(25, I2C_MUX_MODE); // Txd SOC PIN (Arduino header pin 19)
 
 	SET_PIN_PULLUP(24, 1);
@@ -129,6 +129,38 @@ int i2c_openadapter(void)
 
 	return ret;
 }
+
+int i2c_openadapter_speed(int i2c_speed)
+{
+	int ret;
+
+	SET_PIN_MODE(24, I2C_MUX_MODE); // Rxd SOC PIN (Arduino header pin 18)
+	SET_PIN_MODE(25, I2C_MUX_MODE); // Txd SOC PIN (Arduino header pin 19)
+
+	SET_PIN_PULLUP(24, 1);
+	SET_PIN_PULLUP(25, 1);
+
+	i2c_cfg_data_t i2c_cfg;
+	memset(&i2c_cfg, 0, sizeof(i2c_cfg_data_t));
+
+	i2c_cfg.speed = i2c_speed;
+	i2c_cfg.addressing_mode = I2C_7_Bit;
+	i2c_cfg.mode_type = I2C_MASTER;
+	i2c_cfg.cb_tx = ss_i2c_tx;
+	i2c_cfg.cb_rx = ss_i2c_rx;
+	i2c_cfg.cb_err = ss_i2c_err;
+
+	i2c_tx_complete = 0;
+	i2c_rx_complete = 0;
+	i2c_err_detect = 0;
+
+	ss_i2c_set_config(I2C_SENSING_0, &i2c_cfg);
+	ss_i2c_clock_enable(I2C_SENSING_0);
+	ret = wait_dev_ready(I2C_SENSING_0, false);
+
+	return ret;
+}
+
 
 void i2c_setslave(uint8_t addr)
 {

--- a/cores/arduino/i2c.h
+++ b/cores/arduino/i2c.h
@@ -32,6 +32,7 @@ extern "C"{
 #define I2C_ERROR   -2
 
 int i2c_openadapter(void);
+int i2c_openadapter_speed(int);
 void i2c_setslave(uint8_t addr);
 int i2c_writebytes(uint8_t *bytes, uint8_t length, bool no_stop);
 int i2c_readbytes(uint8_t *buf, int length, bool no_stop);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -41,6 +41,11 @@ void TwoWire::begin(void)
 	init_status = i2c_openadapter();
 }
 
+void TwoWire::begin(int i2c_speed)
+{
+	init_status = i2c_openadapter_speed(i2c_speed);
+}
+
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
 {
 	int ret;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -24,12 +24,15 @@
 #include "Stream.h"
 #include "variant.h"
 
-#define BUFFER_LENGTH 32
+#define BUFFER_LENGTH   32
+#define I2C_SPEED_SLOW  1
+#define I2C_SPEED_FAST  2
 
 class TwoWire : public Stream {
 public:
 	TwoWire(void);
 	void begin();
+    void begin(int);
 	void beginTransmission(uint8_t);
 	void beginTransmission(int);
 	uint8_t endTransmission(void);


### PR DESCRIPTION
-adds functionality to change clock speed
-clock speed is set/changed when Wire.begin() is called
-default is standard mode
-call Wire.begin(I2C_SPEED_SLOW) for standard speed (100k)
-call Wire.begin(I2C_SPEED_FAST) for full speed (400k)