### PR TITLE
Jira-560, getInterruptStatus(...) should return type of bool

### DIFF
--- a/libraries/CurieIMU/src/CurieIMU.cpp
+++ b/libraries/CurieIMU/src/CurieIMU.cpp
@@ -1504,7 +1504,7 @@ bool CurieIMUClass::interruptsEnabled(int feature)
     }
 }
 
-int CurieIMUClass::getInterruptStatus(int feature)
+bool CurieIMUClass::getInterruptStatus(int feature)
 {
     switch (feature) {
         case CURIE_IMU_FREEFALL:

--- a/libraries/CurieIMU/src/CurieIMU.h
+++ b/libraries/CurieIMU/src/CurieIMU.h
@@ -180,7 +180,7 @@ class CurieIMUClass : public BMI160Class {
         void noInterrupts(int feature);
         bool interruptsEnabled(int feature);
 
-        int getInterruptStatus(int feature);
+        bool getInterruptStatus(int feature);
 
         CurieIMUStepMode getStepDetectionMode();
         void setStepDetectionMode(int mode);


### PR DESCRIPTION
Please review this change. For all features, all functions returns a 'bool', therefore, the main function should return a bool.

The team advise that I make the change and have your review/approve it.