### PR TITLE
Add SERIAL_PORT_USBVIRTUAL and SerialUSB macros

### DIFF
--- a/variants/arduino_101/variant.h
+++ b/variants/arduino_101/variant.h
@@ -197,9 +197,12 @@ void CDCSerial_bytes_sent(uint32_t num);
 // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
 //                            pins are NOT connected to anything by default.
 #define SERIAL_PORT_MONITOR         Serial
+#define SERIAL_PORT_USBVIRTUAL      Serial
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE1       Serial1
+
+#define SerialUSB   SERIAL_PORT_USBVIRTUAL
 
 extern uint32_t sizeof_g_APinDescription;
 


### PR DESCRIPTION
This is needed to ensure compatibility with YunShield sketches (although the port is not a real CDC port, but all other platforms with a single out - like Leonardo - now have this alias)