### PR TITLE
Bug fixed: CurieBle library, class BLECharacteristic allocates memory…

### DIFF
--- a/libraries/CurieBLE/src/BLECharacteristic.cpp
+++ b/libraries/CurieBLE/src/BLECharacteristic.cpp
@@ -37,7 +37,7 @@ BLECharacteristic::BLECharacteristic(const char* uuid,
     _presentation_format(NULL)
 {
     _value_size = maxLength > BLE_MAX_ATTR_DATA_LEN ? BLE_MAX_ATTR_DATA_LEN : maxLength;
-    _value = (unsigned char*)malloc(_value_length);
+    _value = (unsigned char*)malloc(_value_size);
 
     memset(_event_handlers, 0, sizeof(_event_handlers));
 }


### PR DESCRIPTION
… using an incorrect variable which may result in memory corruption if the memory size is bigger than 16 bytes.
