### PR TITLE
Jira-599.  Routine, dtostrf, did not work with the latest toolchain. …

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -288,62 +288,8 @@ size_t Print::printLongLong(unsigned long long n, uint8_t base) {
 
 size_t Print::printFloat(double number, uint8_t digits)
 {
-  size_t n = 0;
-  int exponent = 0;
-  double tmp;
+  char str[50];
 
-  if (isnan(number)) return print("nan");
-  if (isinf(number)) return print("inf");
-
-  // Handle negative numbers
-  if (number < 0.0) {
-    n += print('-');
-    number = -number;
-  }
-
-  // Chk if integer part has more than 8 digits.
-  tmp = number;
-  while (true) {
-    tmp /= 10.0;
-    exponent++;
-    if (tmp < 10.0)  break;
-  }
-  if (exponent > 8)
-    number = tmp;
-  else
-    exponent = 0;
-
-  // Round correctly so that print(1.999, 2) prints as "2.00"
-  double rounding = 0.5;
-  for (uint8_t i=0; i<digits; ++i)
-    rounding /= 10.0;
-
-  number += rounding;
-
-  // Extract the integer part of the number and print it
-  unsigned long int_part = (unsigned long)number;
-  double remainder = number - (double)int_part;
-  n += print(int_part);
-
-  // Print the decimal point, but only if there are digits beyond
-  if (digits > 0) {
-    n += print(".");
-  }
-
-  // Extract digits from the remainder one at a time
-  while (digits-- > 0)
-  {
-    remainder *= 10.0;
-    int toPrint = int(remainder);
-    n += print(toPrint);
-    remainder -= toPrint;
-  }
-
-  // Print the exponent portion
-  if (exponent) {
-    n += print("e+");
-    n += print(exponent);
-  }
-
-  return n;
+  dtostrf(number, 0, digits, str);
+  return(print(str));
 }

--- a/cores/arduino/stdlib_noniso.h
+++ b/cores/arduino/stdlib_noniso.h
@@ -37,7 +37,7 @@ char* utoa (unsigned int val, char *s, int radix);
 
 char* ultoa (unsigned long val, char *s, int radix);
  
-char* dtostrf (double val, unsigned char width, unsigned char prec, char *s);
+char* dtostrf (double val, signed char width, unsigned char prec, char *s);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
… The call to sprintf in the routine crashed the system.  Issue corrected by replacing the call.  The routine, printFloat, in Print.cpp, is now using dtostrf to print out double and float values.
Please note that dtostrf is almost a complete replacement.  From the AVR library reference description, the input parameter, width, can be negative - left spacing adjustment.