### PR TITLE
Remove unnecessary #undefs

### DIFF
--- a/libraries/CurieSoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/CurieSoftwareSerial/src/SoftwareSerial.h
@@ -96,13 +96,4 @@ public:
 
 };
 
-// Arduino 0012 workaround
-#undef int
-#undef char
-#undef long
-#undef byte
-#undef float
-#undef abs
-#undef round
-
 #endif


### PR DESCRIPTION
-Remove #undefs from CurieSoftwareSerial Library
-Because it was braking some functionality such abs()