### PR TITLE
Jira509: modify the example of motion, zero-motion and freefall

### DIFF
--- a/libraries/CurieIMU/examples/ZeroMotionDetect/ZeroMotionDetect.ino
+++ b/libraries/CurieIMU/examples/ZeroMotionDetect/ZeroMotionDetect.ino
@@ -9,39 +9,52 @@
 */
 #include "CurieIMU.h"
 
-boolean blinkState = false;          // state of the LED
-unsigned long loopTime = 0;          // get the time since program started
-unsigned long interruptsTime = 0;    // get the time when zero motion event is detected
+boolean ledState = false;          // state of the LED
 void setup() {
   Serial.begin(9600);
   while(!Serial);   // wait for the serial port to open
 
   /* Initialise the IMU */
-  blinkState = CurieIMU.begin();
+  CurieIMU.begin();
   CurieIMU.attachInterrupt(eventCallback);
 
   /* Enable Zero Motion Detection */
-  CurieIMU.setDetectionThreshold(CURIE_IMU_ZERO_MOTION, 1500); // 1.5g=1500mg
-  CurieIMU.setDetectionDuration(CURIE_IMU_ZERO_MOTION, 25);    // 25s
+  CurieIMU.setDetectionThreshold(CURIE_IMU_ZERO_MOTION, 50);  // 50mg
+  CurieIMU.setDetectionDuration(CURIE_IMU_ZERO_MOTION, 2);    // 2s
   CurieIMU.interrupts(CURIE_IMU_ZERO_MOTION);
+
+  /* Enable Motion Detection */
+  CurieIMU.setDetectionThreshold(CURIE_IMU_MOTION, 20);      // 20mg
+  CurieIMU.setDetectionDuration(CURIE_IMU_MOTION, 10);       // trigger times of consecutive slope data points
+  CurieIMU.interrupts(CURIE_IMU_MOTION);
 
   Serial.println("IMU initialisation complete, waiting for events...");
 }
 
 void loop() {
-  //if zero motion is detected in 1500ms, LED will be turned up
-  loopTime = millis();
-  if(abs(loopTime -interruptsTime) < 1500)     
-    blinkState = true;
-  else
-    blinkState = false;
-  digitalWrite(13, blinkState);
+  // if zero motion is detected, LED will be turned up. 
+  digitalWrite(13, ledState);
 }
 
 static void eventCallback(void){
   if (CurieIMU.getInterruptStatus(CURIE_IMU_ZERO_MOTION)) {
-    interruptsTime = millis(); 
+    ledState = true; 
     Serial.println("zero motion detected...");
+  }  
+  if (CurieIMU.getInterruptStatus(CURIE_IMU_MOTION)) {
+    ledState = false;
+    if (CurieIMU.motionDetected(X_AXIS, POSITIVE))
+      Serial.println("Negative motion detected on X-axis");
+    if (CurieIMU.motionDetected(X_AXIS, NEGATIVE))
+      Serial.println("Positive motion detected on X-axis");
+    if (CurieIMU.motionDetected(Y_AXIS, POSITIVE))
+      Serial.println("Negative motion detected on Y-axis");
+    if (CurieIMU.motionDetected(Y_AXIS, NEGATIVE))
+      Serial.println("Positive motion detected on Y-axis");
+    if (CurieIMU.motionDetected(Z_AXIS, POSITIVE))
+      Serial.println("Negative motion detected on Z-axis");
+    if (CurieIMU.motionDetected(Z_AXIS, NEGATIVE))
+      Serial.println("Positive motion detected on Z-axis");
   }  
 }
 

--- a/libraries/CurieIMU/src/CurieIMU.cpp
+++ b/libraries/CurieIMU/src/CurieIMU.cpp
@@ -432,8 +432,6 @@ float CurieIMUClass::getDetectionThreshold(int feature)
             return getTapDetectionThreshold();
 
         case CURIE_IMU_STEP:
-        case CURIE_IMU_TAP_SHOCK:
-        case CURIE_IMU_TAP_QUIET:
         case CURIE_IMU_DOUBLE_TAP:
         case CURIE_IMU_FIFO_FULL:
         case CURIE_IMU_DATA_READY:
@@ -466,8 +464,6 @@ void CurieIMUClass::setDetectionThreshold(int feature, float threshold)
             break;
 
         case CURIE_IMU_STEP:
-        case CURIE_IMU_TAP_SHOCK:
-        case CURIE_IMU_TAP_QUIET:
         case CURIE_IMU_DOUBLE_TAP:
         case CURIE_IMU_FIFO_FULL:
         case CURIE_IMU_DATA_READY:
@@ -795,7 +791,7 @@ void CurieIMUClass::setDetectionDuration(int feature, float value)
             break;
 
         case CURIE_IMU_ZERO_MOTION:
-            setZeroMotionDetectionThreshold(value);
+            setZeroMotionDetectionDuration(value);
             break;
 
         case CURIE_IMU_TAP_QUIET:
@@ -1465,8 +1461,6 @@ void CurieIMUClass::enableInterrupt(int feature, bool enabled)
             setIntDataReadyEnabled(enabled);
             break;
 
-        case CURIE_IMU_TAP_QUIET:
-        case CURIE_IMU_TAP_SHOCK:
         default:
             break;
     }
@@ -1502,8 +1496,6 @@ bool CurieIMUClass::interruptsEnabled(int feature)
         case CURIE_IMU_DATA_READY:
             return getIntDataReadyEnabled();
 
-        case CURIE_IMU_TAP_QUIET:
-        case CURIE_IMU_TAP_SHOCK:
         default:
             return false;
     }
@@ -1539,8 +1531,6 @@ bool CurieIMUClass::getInterruptStatus(int feature)
         case CURIE_IMU_DATA_READY:
             return getIntDataReadyStatus();
 
-        case CURIE_IMU_TAP_QUIET:
-        case CURIE_IMU_TAP_SHOCK:
         default:
             return false;
     }


### PR DESCRIPTION
@xieqi @sgbhu @SidLeung 
Jira509:add 'while (! serial);' and change the copyright to 2016; fix indicator light behavior for IMU example ZeroMotionDetect.
