### PR TITLE
Jira-617: String Object constructor hangs up when handling large floa…

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -133,23 +133,23 @@ String::String(unsigned long long value, unsigned char base)
 
 String::String(float value, unsigned char decimalPlaces)
 {
-	int len = digitsBe4Decimal(value);
+	int totalSize = digitsBe4Decimal(value);
 	init();
 
-	if(decimalPlaces)  len += 1 + ((int)decimalPlaces & 0x0FF);
+	if(decimalPlaces)  totalSize += 1 + ((int)decimalPlaces & 0x0FF);
 
-	char buf[len+1];
+	char buf[totalSize+1];
 	*this = dtostrf(value, 0, decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces)
 {
-	int len = digitsBe4Decimal(value);
+	int totalSize = digitsBe4Decimal(value);
 	init();
 
-	if(decimalPlaces)  len += 1 + ((int)decimalPlaces & 0x0FF);
+	if(decimalPlaces)  totalSize += 1 + ((int)decimalPlaces & 0x0FF);
 
-	char buf[len+1];
+	char buf[totalSize+1];
 	*this = dtostrf(value, 0, decimalPlaces, buf);
 }
 
@@ -814,18 +814,17 @@ float String::toFloat(void) const
 
 int String::digitsBe4Decimal(double number)
 {
-  int cnt = 0;
-  long tmp = (long)number;  // Drop the decimal here
+  int cnt = 1;  // Always has one digit
 
   // Count -ve sign as one digit
-  if(tmp < 0) {
+  if(number < 0.0) {
     cnt++;
-    tmp = -tmp;
+    number = -number;
   }
 
-  // Count the number of digit
-  while(tmp) {
-    tmp /= 10;
+  // Count the number of digits beyond the 1st, basically, the exponent.
+  while(number >= 10.0) {
+    number /= 10;
     cnt++;
   }
   return cnt;


### PR DESCRIPTION
…ting point number

There is a bug in determining the number of digits before the decimal point of a floating point number.  The method employed used casting to rid of the decimal portion of the floating point value that resulted in an incorrect number of digits if the floating point value is large enough (overflow condition).

Casting removed.  Used another method to determine the number of digits in the integer portion of a floating point number (exponent count).