### PR TITLE
ATLEDGE-572: Fix getStepDetectionMode()

### DIFF
--- a/libraries/CurieIMU/src/BMI160.cpp
+++ b/libraries/CurieIMU/src/BMI160.cpp
@@ -824,7 +824,10 @@ uint8_t BMI160Class::getStepDetectionMode() {
     uint8_t ret_step_conf0, ret_min_step_buf;
 
     ret_step_conf0 = reg_read(BMI160_RA_STEP_CONF_0);
-    ret_min_step_buf = reg_read(BMI160_RA_STEP_CONF_1);
+
+    /* min_step_buf is the first 3 bits of RA_STEP_CONF_1; the
+     * 4th bit is the enable bit (step_cnt_en) */
+    ret_min_step_buf = reg_read_bits(BMI160_RA_STEP_CONF_1, 0, 3);
 
     if ((ret_step_conf0 == BMI160_RA_STEP_CONF_0_NOR) && (ret_min_step_buf == BMI160_RA_STEP_CONF_1_NOR))
         return BMI160_STEP_MODE_NORMAL;


### PR DESCRIPTION
This function is reading all 8 bits of RA_STEP_CONF_1 (0x7A-0x7B)
to obtain a value for min_step_buf, though this value is only
represented by the lower 3 bits; bit 4 is used as the 'enable' bit.
As a consequence, this function will read the step detection mode
incorrectly when step counting is enabled. Fix this by only reading
the lower 3 bits of RA_STEP_CONF_1.