### PR TITLE
ATLEDGE-619: fix dtostrf

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -813,26 +813,3 @@ float String::toFloat(void) const
         if (buffer) return float(atof(buffer));
         return 0;
 }
-
-/*********************************************/
-/*  utilities functions                      */
-/*********************************************/
-
-int String::digitsBe4Decimal(double number)
-{
-  int cnt = 1;  // Always has one digit
-
-  // Count -ve sign as one digit
-  if(number < 0.0) {
-    cnt++;
-    number = -number;
-  }
-
-  // Count the number of digits beyond the 1st, basically, the exponent.
-  while(number >= 10.0) {
-    number /= 10;
-    cnt++;
-  }
-  return cnt;
-}
-

--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -217,10 +217,6 @@ protected:
        #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 	void move(String &rhs);
 	#endif
-
-	// utilities functions.
-	// Number of digits (including sign) in the integer portion of a float/double
-	int digitsBe4Decimal(double number);
 };
 
 class StringSumHelper : public String

--- a/cores/arduino/stdlib_noniso.h
+++ b/cores/arduino/stdlib_noniso.h
@@ -39,6 +39,8 @@ char* ultoa (unsigned long val, char *s, int radix);
  
 char* dtostrf (double val, signed char width, unsigned char prec, char *s);
 
+int digitsBe4Decimal(double number);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Use a different method for float->string conversion, and
fix the width calculation so that extra spaces are only
printed if the width parameter exceeds the output string
length (ie. a mininum width, as specified by dtostrf
reference from avr-libc).