### PR TITLE
Add CurieIMUClass::end()

### DIFF
--- a/libraries/CurieIMU/src/CurieIMU.cpp
+++ b/libraries/CurieIMU/src/CurieIMU.cpp
@@ -57,6 +57,11 @@ bool CurieIMUClass::begin()
     return (CURIE_IMU_CHIP_ID == getDeviceID());
 }
 
+void CurieIMUClass::end()
+{
+    ss_spi_disable();
+}
+
 int CurieIMUClass::getGyroRate()
 {
     int rate;

--- a/libraries/CurieIMU/src/CurieIMU.h
+++ b/libraries/CurieIMU/src/CurieIMU.h
@@ -95,6 +95,7 @@ class CurieIMUClass : public BMI160Class {
 
     public:
         bool begin(void);
+        void end(void);
 
         // supported values: 25, 50, 100, 200, 400, 800, 1600, 3200 (Hz)
         int getGyroRate();

--- a/libraries/CurieIMU/src/internal/ss_spi.c
+++ b/libraries/CurieIMU/src/internal/ss_spi.c
@@ -73,6 +73,12 @@ void ss_spi_init()
     SS_SPI_REG_WRITE(INTR_MASK, SPI_DISABLE_INT);
 }
 
+void ss_spi_disable()
+{
+    /* gate SPI controller clock */
+    SS_SPI_REG_WRITE(CTRL, 0);
+}
+
 static inline
 void spi_transmit(uint8_t *buf, size_t count, boolean_t waitCompletion) {
     while (count--)

--- a/libraries/CurieIMU/src/internal/ss_spi.h
+++ b/libraries/CurieIMU/src/internal/ss_spi.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 void ss_spi_init();
+void ss_spi_disable();
 int ss_spi_xfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add end() method to IMU class, to disable clocking to the SPI
controller. This is unlikely to have noticeable power-saving effects,
however it is a good habit to get into.