### PR TITLE
Jira566: I2S DMA implement: supplement library and example

### DIFF
--- a/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
+++ b/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
@@ -38,7 +38,7 @@ void loop()
     dataBuff[i] = i + 1 + (loop_count<<16);
   }
   loop_count++;
-  int status = CurieI2SDMA.transTX(dataBuff,sizeof(dataBuff));
+  int status = CurieI2SDMA.transTX(dataBuff,sizeof(dataBuff),sizeof(uint32_t));
   if(status)
     return;
    

--- a/libraries/CurieI2S/src/CurieI2SDMA.h
+++ b/libraries/CurieI2S/src/CurieI2SDMA.h
@@ -47,6 +47,8 @@ class Curie_I2SDMA
 	public:
 		Curie_I2SDMA();
 
+		void lastFrameDelay();
+    
 		//
 		int beginTX(uint16_t sample_rate,uint8_t resolution,uint8_t master,uint8_t mode);
 		//
@@ -58,16 +60,16 @@ class Curie_I2SDMA
 		int iniRX();
 
 		// starts transmission of data to the tx channel
-		int transTX(uint32_t* buf_TX,uint32_t len);
+		int transTX(void* buf_TX,uint32_t len,uint32_t len_per_data);
 
 		// starts listening to the rx channel
-		int transRX(uint32_t* buf_RX,uint32_t len);
+		int transRX(void* buf_RX,uint32_t len,uint32_t len_per_data);
 
 		// merge data of left and right channel into one buffer
-		int mergeData(uint32_t* buf_left,uint32_t* buf_right,uint32_t* buf_TX);
+		int mergeData(void* buf_left,void* buf_right,void* buf_TX,uint32_t length_TX,uint32_t len_per_data);
         
 		// seperate the data to left and right channl
-		int separateData(uint32_t* buf_left,uint32_t* buf_right,uint32_t* buf_RX);        
+		int separateData(void* buf_left,void* buf_right,void* buf_RX,uint32_t length_RX,uint32_t len_per_data);        
         	
 		//
 		void stopTX();

--- a/system/libarc32_arduino101/drivers/soc_i2s.h
+++ b/system/libarc32_arduino101/drivers/soc_i2s.h
@@ -143,7 +143,7 @@ DRIVER_API_RC soc_i2s_deconfig(uint8_t channel);
  *           - DRV_RC_OK on success
  *           - DRV_RC_FAIL otherwise
  */
-DRIVER_API_RC soc_i2s_write(uint32_t *buf, uint32_t len);
+DRIVER_API_RC soc_i2s_write(void *buf, uint32_t len, uint32_t len_per_data);
 
 /**
  *  Function to continuously transmit blocks of audio data
@@ -157,7 +157,7 @@ DRIVER_API_RC soc_i2s_write(uint32_t *buf, uint32_t len);
  *           - DRV_RC_OK on success
  *           - DRV_RC_FAIL otherwise
  */
-DRIVER_API_RC soc_i2s_stream(uint32_t *buf, uint32_t len, uint32_t num_bufs);
+DRIVER_API_RC soc_i2s_stream(void *buf, uint32_t len, uint32_t len_per_data, uint32_t num_bufs);
 
 /**
  *  Function to stop a continuous audio data write
@@ -178,7 +178,7 @@ DRIVER_API_RC soc_i2s_stop_stream(void);
  *           - DRV_RC_OK on success
  *           - DRV_RC_FAIL otherwise
  */
-DRIVER_API_RC soc_i2s_read(uint32_t *buf, uint32_t len);
+DRIVER_API_RC soc_i2s_read(void *buf, uint32_t len, uint32_t len_per_data);
 
 /**
  *  Function to continuously receive blocks of audio data
@@ -192,7 +192,7 @@ DRIVER_API_RC soc_i2s_read(uint32_t *buf, uint32_t len);
  *           - DRV_RC_OK on success
  *           - DRV_RC_FAIL otherwise
  */
-DRIVER_API_RC soc_i2s_listen(uint32_t *buf, uint32_t len, uint8_t num_bufs);
+DRIVER_API_RC soc_i2s_listen(void *buf, uint32_t len,  uint32_t len_per_data, uint8_t num_bufs);
 
 /**
  *  Function to stop a continuous audio data read


### PR DESCRIPTION
@SidLeung @calvinatintel@xieqi @sgbhu update the I2S DMA implement codes:(1) work well on different sample resolution(12,16,24,32 bits);(2)  Put a time delay in the interrupt to make clock stay longer to make sure all data have been arrived RX side. And don't need to push extra zero to register at TX side any more.