### PR TITLE
Issue #241: make Serial1 release GPIO pins on end()

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -112,6 +112,9 @@ void UARTClass::end( void )
   opened = false;
   // Clear any received data
   _rx_buffer->_iHead = _rx_buffer->_iTail;
+
+  SET_PIN_MODE(17, GPIO_MUX_MODE); // Rdx SOC PIN (Arduino header pin 0)
+  SET_PIN_MODE(16, GPIO_MUX_MODE); // Txd SOC PIN (Arduino header pin 1)
 }
 
 void UARTClass::setInterruptPriority(uint32_t priority)


### PR DESCRIPTION
UARTClass::init() muxes out the UART pins to Arduino header pins 0/1.
Reset the mux on UARTClass::end() so that pins 0/1 can be used as GPIOs
again.