### PR TITLE
ATLEDGE-643: Add chip ID to SerialFlash example sketch

### DIFF
--- a/libraries/SerialFlash/examples/RawHardwareTest/RawHardwareTest.ino
+++ b/libraries/SerialFlash/examples/RawHardwareTest/RawHardwareTest.ino
@@ -391,6 +391,7 @@ const char * id2chip(const unsigned char *id)
 		// Winbond
 		if (id[1] == 0x40) {
 			if (id[2] == 0x14) return "W25Q80BV";
+			if (id[2] == 0x15) return "W25Q16DV";
 			if (id[2] == 0x17) return "W25Q64FV";
 			if (id[2] == 0x18) return "W25Q128FV";
 			if (id[2] == 0x19) return "W25Q256FV";


### PR DESCRIPTION
RawHardwareTest reports the 101's on-board SPI flash chip as an unknown
device. Fix this by adding the device's JEDEC ID to the example sketch.