### PR TITLE
Add delay to Serial1.end() allow GPIO lines to settle

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -25,6 +25,8 @@
 #include "wiring_constants.h"
 #include "wiring_digital.h"
 
+#define SETTLING_TIME  400
+
 extern void UART_Handler(void);
 extern void serialEventRun(void) __attribute__((weak));
 extern void serialEvent(void) __attribute__((weak));
@@ -115,6 +117,7 @@ void UARTClass::end( void )
 
   SET_PIN_MODE(17, GPIO_MUX_MODE); // Rdx SOC PIN (Arduino header pin 0)
   SET_PIN_MODE(16, GPIO_MUX_MODE); // Txd SOC PIN (Arduino header pin 1)
+  delayMicroseconds(SETTLING_TIME); // wait for lines to settle
 }
 
 void UARTClass::setInterruptPriority(uint32_t priority)


### PR DESCRIPTION
Through testing, it was discovered that if Serial1.begin() is called again
immediately after Serial1.end(), then any attempt to write data immediately
following the begin() call could result in corrupted frames.

After calling Serial1.end(), it will be at least 300us before those pins can
be used as UART again.