### PR TITLE
Fix serial flush

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -169,7 +169,7 @@ void UARTClass::flush( void )
 {
   while (_tx_buffer->_iHead != _tx_buffer->_iTail); //wait for transmit data to be sent
   // Wait for transmission to complete
-  while (uart_irq_tx_ready(CONFIG_UART_CONSOLE_INDEX));
+  while(!uart_tx_complete(CONFIG_UART_CONSOLE_INDEX));
 }
 
 size_t UARTClass::write( const uint8_t uc_data )

--- a/system/libarc32_arduino101/drivers/ns16550.c
+++ b/system/libarc32_arduino101/drivers/ns16550.c
@@ -626,3 +626,16 @@ void uart_int_connect(int which,	   /* UART to which to connect */
 	/* set the Host Processor Interrupt Routing Mask */
 	SOC_UNMASK_INTERRUPTS(INT_UART_0_MASK + (which * UART_REG_ADDR_INTERVAL));
 }
+
+/*******************************************************************************
+*
+* uart_tx_complete - check if tx holding and shift register are empty
+*
+* RETURNS: zero if registers are non-empty (transmission not complete), 
+*          non-zero if registers are empty (transmission complete)
+*/
+
+uint8_t uart_tx_complete(int which)
+{
+	return INBYTE(LSR(which)) & LSR_TEMT;
+}

--- a/system/libarc32_arduino101/drivers/uart.h
+++ b/system/libarc32_arduino101/drivers/uart.h
@@ -91,6 +91,7 @@ int uart_line_status(int port);
 int uart_break_check(int port);
 void uart_break_send(int port, int delay);
 void uart_disable(int port);
+uint8_t uart_tx_complete(int which);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, flush wait for the transmission to be complete by checking if the transmission holding register (or fifo) is empty.
When this happen, the last byte is still in the shift register, and has still to be transmitted. This mean we can't know when the transmission is actually complete, which is crucial to implement RS485 communication, for example.
This pull request change this behaviour and wait for the shift register to be empty, which means the transmission is really complete. 
This new behaviour is  also more consistent with the behaviour of flus on AVR boards.

Note that the change have not be extensively tested, and i am not sure this is entirely correct, so it would be good if someone with a better knowledge of the uart device could have a look.