### PR TITLE
Fix UART receiver corruption when data sent after short disconnection

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -25,8 +25,6 @@
 #include "wiring_constants.h"
 #include "wiring_digital.h"
 
-#define SETTLING_TIME  400
-
 extern void UART_Handler(void);
 extern void serialEventRun(void) __attribute__((weak));
 extern void serialEvent(void) __attribute__((weak));
@@ -114,10 +112,13 @@ void UARTClass::end( void )
   opened = false;
   // Clear any received data
   _rx_buffer->_iHead = _rx_buffer->_iTail;
+  
+  //enable loopback, needed to prevent a short disconnection to be 
+  //interpreted as a packet and corrupt receiver state
+  uart_loop_enable(CONFIG_UART_CONSOLE_INDEX);
 
   SET_PIN_MODE(17, GPIO_MUX_MODE); // Rdx SOC PIN (Arduino header pin 0)
   SET_PIN_MODE(16, GPIO_MUX_MODE); // Txd SOC PIN (Arduino header pin 1)
-  delayMicroseconds(SETTLING_TIME); // wait for lines to settle
 }
 
 void UARTClass::setInterruptPriority(uint32_t priority)

--- a/system/libarc32_arduino101/drivers/ns16550.c
+++ b/system/libarc32_arduino101/drivers/ns16550.c
@@ -639,3 +639,39 @@ uint8_t uart_tx_complete(int which)
 {
 	return INBYTE(LSR(which)) & LSR_TEMT;
 }
+
+/*******************************************************************************
+*
+* uart_loop_enable - enable loopback
+*
+* This function enable the local loopback.
+* When enabled, the output of the Transmitter Shift
+* Register is looped back into the Receiver Shift Register input,
+* and any data that is transmitted is immediately received.
+*
+* RETURNS: N/A
+*/
+
+void uart_loop_enable(int which)
+{
+	uint8_t mdc = INBYTE(MDC(which));
+	mdc |= MCR_LOOP;
+	OUTBYTE(MDC(which), mdc);
+}
+
+/*******************************************************************************
+*
+* uart_loop_disable - disable loopback
+*
+* This function disable the local loopback.
+*
+* RETURNS: N/A
+*/
+
+void uart_loop_disable(int which)
+{
+	uint8_t mdc = INBYTE(MDC(which));
+	mdc &= ~MCR_LOOP;
+	OUTBYTE(MDC(which), mdc);
+}
+

--- a/system/libarc32_arduino101/drivers/uart.h
+++ b/system/libarc32_arduino101/drivers/uart.h
@@ -92,6 +92,8 @@ int uart_break_check(int port);
 void uart_break_send(int port, int delay);
 void uart_disable(int port);
 uint8_t uart_tx_complete(int which);
+void uart_loop_enable(int which);
+void uart_loop_disable(int which);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a workarround for a very subtle bug that affect the UART receiver, and that was discussed in https://github.com/01org/corelibs-arduino101/pull/259.

When the UART receiver is disconnected (with SET_PIN_MODE(17, GPIO_MUX_MODE)) for a time shorter than a line break and longer than a start bit, it interpret that as a received packet, and if data are transmitted immediatly after, they are corrupted.
This commit is a workarround for that bug, that enable the loopback feature of the UART when UART is disconnected, so the UART module does not notice it is disconnected.
A previous workarround for this bug (a forced delay after disconnection) is not needed anymore and is removed.

Here is a example code that shows how a false packet can be received with the good timing (rx and tx pins must be connected) : 
[Serial2_error.ino.txt](https://github.com/01org/corelibs-arduino101/files/405052/Serial2_error.ino.txt).
You should receive a value of 0xF0. You may also try to send data just after the second begin to see the data corruption. In this case the best is probably to draw the waveforms on a sheet of paper to understand what happen.

The best way to fix it would probably be to stop completely the receiver when disconnected, or to reset completely its state when reconnected, but i have not find any way to do it (i may have missed something obvious, though). 
This workarround seems to do the job, however, and fix the issue for the test code proposed in https://github.com/01org/corelibs-arduino101/pull/259#issuecomment-237583896 . If you have more test case, they are very welcome. (actually, would'nt it be a good idea to include those tests in the repository, for documentation and regression testing?)

Since https://github.com/01org/corelibs-arduino101/pull/259 might also appear in your tests, i keep a branch https://github.com/descampsa/corelibs-arduino101/tree/fix_uart that merge the two pull requests, that i recommend you to use for your tests. (not sure if it the best way to do it?)