### PR TITLE
CurieSMC library fixes

### DIFF
--- a/libraries/CurieSMC/examples/smcTest/smcTest.ino
+++ b/libraries/CurieSMC/examples/smcTest/smcTest.ino
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 Intel Corporation.  All rights reserved.
+ * See the bottom of this file for the license terms.
+ */
+
+/*
+ * This sketch example demonstrates a simple way to use the Shared Memory Communication library between 
+ * the ARC and Quark cores. 
+ * It requires that the firmware be upgraded to one that supports the Shared Memory Communication library.
+ * This sketch example will need to be used with the smc example built using the CODK-M tree.
+ * 
+ * This sketch sends values to the Quark core which then reads those values, doubles them and sends it back to the ARC core.
+ * This sketch then reads those values and displays the doubled values.
+ */
+
+#include <CurieSMC.h>
+
+void setup() 
+{
+  Serial.begin(384000);
+  while(!Serial);
+  SMC.begin();
+}
+
+void loop() 
+{
+  for(int i = 0; i < 32; i++)
+  {
+    Serial.print("writing : ");
+    Serial.println(i);
+    SMC.write(i);
+  }
+  while(SMC.availableForRead())
+  {
+    Serial.print("data: ");
+    Serial.println(SMC.read());
+  }
+  
+  delay(1000);
+}
+
+/*
+   Copyright (c) 2016 Intel Corporation.  All rights reserved.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+

--- a/libraries/CurieSMC/src/CurieSMC.cpp
+++ b/libraries/CurieSMC/src/CurieSMC.cpp
@@ -14,13 +14,11 @@ void CurieSMC::begin()
 int CurieSMC::write(uint8_t data)
 {
   //check if buffer is available
-  if(ARC_BUFF_FLAG == 1)
-  {
+  if(ARC_BUFF_FLAG == 0)
     return 1;
-  }
   
   //lock the buffer
-  ARC_BUFF_FLAG = 0;
+  ARC_BUFF_FLAG = 1;
   
   int new_head = (int)(ARC_BUFF_HEAD+1)%SHARED_BUFFER_SIZE;
   if(new_head != ARC_BUFF_TAIL)
@@ -30,23 +28,21 @@ int CurieSMC::write(uint8_t data)
   }
   else
   {
+    ARC_BUFF_FLAG = 2; //unlock the buffer
     return 2; //buffer is full
   }
-
-  //unlock the buffer
-  ARC_BUFF_FLAG = 2;
-
+  
+  ARC_BUFF_FLAG = 2; //unlock the buffer
   return 0;
 }
 
 uint8_t CurieSMC::read()
 {
   //check if buffer is available
-  if(QUARK_BUFF_FLAG == 1)
-    return 0;
+  while(QUARK_BUFF_FLAG == 0); //wait for Quark core to release the buffer
 
   //lock the buffer
-  QUARK_BUFF_FLAG = 0;
+  QUARK_BUFF_FLAG = 1;
   
   if(availableForRead())
   {


### PR DESCRIPTION
-properly set flags for both cores during read() and write()
-add example sketch for CurieSMC library