### PR TITLE
Make String::move of an invalidated String result in an invalidated String

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -227,7 +227,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 void String::move(String &rhs)
 {
 	if (buffer) {
-		if (capacity >= rhs.len) {
+		if (rhs && capacity >= rhs.len) {
 			strcpy(buffer, rhs.buffer);
 			len = rhs.len;
 			rhs.len = 0;


### PR DESCRIPTION
Port of https://github.com/arduino/Arduino/pull/5127 to 101 core.

Please see https://github.com/arduino/Arduino/pull/5127#issue-165187941 for more discussion of what this change fixes. Note: this change has also been integrated in the SAMD core in https://github.com/arduino/ArduinoCore-samd/issues/153.