### PR TITLE
Improve sketches of different libraries that use Serial communication

### DIFF
--- a/libraries/CurieSoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
+++ b/libraries/CurieSoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
@@ -34,7 +34,7 @@ void setup()
   // Open serial communications and wait for port to open:
   Serial.begin(115200);
   while (!Serial) {
-    ; // wait for serial port to connect. Needed for Leonardo only
+    ; // wait for serial port to connect. Needed for Native USB only
   }
 
 

--- a/libraries/CurieTime/examples/ReadTest/ReadTest.ino
+++ b/libraries/CurieTime/examples/ReadTest/ReadTest.ino
@@ -6,8 +6,8 @@
 #include <CurieTime.h>
 
 void setup() {
-  while (!Serial);
-  Serial.begin(9600);
+  Serial.begin(9600); // initialize Serial communication
+  while (!Serial);    // wait for serial port to connect.
 
   Serial.println("CurieTime Read Test");
   Serial.println("-------------------");

--- a/libraries/CurieTime/examples/SetTime/SetTime.ino
+++ b/libraries/CurieTime/examples/SetTime/SetTime.ino
@@ -6,8 +6,8 @@
 #include <CurieTime.h>
 
 void setup() {
-  while (!Serial);
-  Serial.begin(9600);
+  Serial.begin(9600); // initialize Serial communication
+  while(!Serial) ;    // wait for serial port to connect.
 
   // set the current time to 14:27:00, December 14th, 2015
   setTime(14, 27, 00, 14, 12, 2015);

--- a/libraries/CurieTimerOne/examples/CurieTimer1BlinkSpeed/CurieTimer1BlinkSpeed.ino
+++ b/libraries/CurieTimerOne/examples/CurieTimer1BlinkSpeed/CurieTimer1BlinkSpeed.ino
@@ -5,7 +5,8 @@ const int blinkPin = 13;
 void setup(void)
 {
   CurieTimerOne.initialize(50000);
-  Serial.begin(9600);
+  Serial.begin(9600); // initialize Serial communication
+  while(!Serial) ;    // wait for serial port to connect.
 }
 
 void loop(void)

--- a/libraries/CurieTimerOne/examples/CurieTimer1Interrupt/CurieTimer1Interrupt.ino
+++ b/libraries/CurieTimerOne/examples/CurieTimer1Interrupt/CurieTimer1Interrupt.ino
@@ -38,8 +38,8 @@ void timedBlinkIsr()   // callback function when interrupt is asserted
 void setup() {
 
 #ifdef SERIAL_PORT_LOG_ENABLE
-  Serial.begin(115200);
-  while (!Serial);  //  wait for the serial monitor to open
+  Serial.begin(115200);  //  initialize Serial communication
+  while (!Serial);       //  wait for the serial monitor to open
 #endif
 
   // Initialize pin 13 as an output - onboard LED.

--- a/libraries/SPI/examples/BarometricPressureSensor/BarometricPressureSensor.ino
+++ b/libraries/SPI/examples/BarometricPressureSensor/BarometricPressureSensor.ino
@@ -38,7 +38,8 @@ const int dataReadyPin = 6;
 const int chipSelectPin = 7;
 
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(9600); // initialize Serial communication
+  while(!Serial) ;    // wait for serial port to connect.
 
   // start the SPI library:
   SPI.begin();

--- a/libraries/SerialFlash/examples/CopyFromSerial/CopyFromSerial.ino
+++ b/libraries/SerialFlash/examples/CopyFromSerial/CopyFromSerial.ino
@@ -82,7 +82,8 @@
 #define CSPIN             21
 
 void setup(){
-  Serial.begin(9600);  //Teensy serial is always at full USB speed and buffered... the baud rate here is required but ignored
+  Serial.begin(9600); // initialize Serial communication
+  while(!Serial) ;    // wait for serial port to connect.
 
   pinMode(13, OUTPUT);
   


### PR DESCRIPTION
Pull request to improve sketches of CurieSoftwareSerial, CurieTime, CurieTimerOne, SPI and SerialFlash libraries that use Serial communication.
Despite the modified sketches belong to different libraries, I have made a single pull request since, for all the improved sketches, the main intent is to add more documentation and the line 
`while (!Serial); ` in order to wait for the Serial port to open because, in the modified sketches, Serial communication is managed through the virtual serial port (over USB) using the object _Serial_

Best regards