### PR TITLE
stdlib_noniso.cpp: fix dtostrf() handling of integral portion

### DIFF
--- a/cores/arduino/stdlib_noniso.cpp
+++ b/cores/arduino/stdlib_noniso.cpp
@@ -221,7 +221,7 @@ char *dtostrf(double number, signed char width, unsigned char prec, char *s)
 
     // generate chars for each digit of the integral part
     i = before;
-    while (integer > 10) {
+    while (integer >= 10) {
         digit = integer % 10;
         out[(i--) - 1] = ASCII_ZERO + digit;
         integer /= 10;


### PR DESCRIPTION
Checking only for > 10 here (rather than >= 10) means that numbers with a
leading '10' in the integral portion generate incorrect strings.