### PR TITLE
WString: add `toDouble`

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -810,6 +810,11 @@ long String::toInt(void) const
 
 float String::toFloat(void) const
 {
-        if (buffer) return float(atof(buffer));
-        return 0;
+	return (float)toDouble();
+}
+
+double String::toDouble(void) const
+{
+	if (buffer) return atof(buffer);
+	return 0;
 }

--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -199,6 +199,7 @@ public:
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;
+	double toDouble(void) const;
 	char * getCSpec(int base, bool issigned, bool islong);
 
 protected:


### PR DESCRIPTION
Port of https://github.com/arduino/Arduino/pull/5362.

(The spacing in `toFloat` was inconsistent previously, so also made it uniform.