### PR TITLE
CurieMailbox examples: use Serial instead of Serial1

### DIFF
--- a/libraries/CurieMailbox/examples/SharedCounter/SharedCounter.ino
+++ b/libraries/CurieMailbox/examples/SharedCounter/SharedCounter.ino
@@ -26,9 +26,7 @@ int sendChannel = 0;     /* We'll send mailbox messages on this channel */
 int receiveChannel = 1;  /* And receive them on this channel */
 
 void setup (void) {
-    /* Printing to Serial1, since this example uses custom x86 firmware
-     * which lacks the CDC-ACM driver that makes the Serial class work */
-    Serial1.begin(9600);
+    Serial.begin(9600);
 
     /* Enable the mailbox */
     CurieMailbox.begin();
@@ -55,9 +53,9 @@ void loop (void) {
     /* Read the response */
     inMsg = CurieMailbox.get();
 
-    Serial1.print("Sent '" + String(outMsg.data[0]) + "' on channel ");
-    Serial1.print(String(outMsg.channel) + ", got reply '" + String(inMsg.data[0]));
-    Serial1.println("' on channel " + String(inMsg.channel));
+    Serial.print("Sent '" + String(outMsg.data[0]) + "' on channel ");
+    Serial.print(String(outMsg.channel) + ", got reply '" + String(inMsg.data[0]));
+    Serial.println("' on channel " + String(inMsg.channel));
 
     /* Update our count value with the value received from mailbox */
     count = inMsg.data[0] + 1;

--- a/libraries/CurieMailbox/examples/String/String.ino
+++ b/libraries/CurieMailbox/examples/String/String.ino
@@ -18,9 +18,7 @@
 int receiveChannel = 0;  /* Receiving messages on this channel */
 
 void setup (void) {
-    /* Printing to Serial1, since this example uses custom x86 firmware
-     * which lacks the CDC-ACM driver that makes the Serial class work */
-    Serial1.begin(9600);
+    Serial.begin(9600);
 
     /* Enable the mailbox */
     CurieMailbox.begin();
@@ -32,8 +30,8 @@ void setup (void) {
 void printMessageAsString (CurieMailboxMsg msg)
 {
     char *p = (char *)msg.data;
-    Serial1.print("Received message '" + String(p) + "' from channel ");
-    Serial1.println(msg.channel);
+    Serial.print("Received message '" + String(p) + "' from channel ");
+    Serial.println(msg.channel);
 }
 
 void loop (void) {


### PR DESCRIPTION
Mailbox X86 examples now have CDC-ACM support

@calvinatintel @bigdinotech please review.

https://github.com/01org/CODK-M-X86-Samples/pull/17 must be merged before this one.