### PR TITLE
Remove I2S_MODE_SCK_POL bit from I2S modes

### DIFF
--- a/system/libarc32_arduino101/drivers/soc_i2s.h
+++ b/system/libarc32_arduino101/drivers/soc_i2s.h
@@ -63,13 +63,10 @@ extern "C" {
 #define I2S_MODE_SAMPLE_DEL (0x10)
 #define I2S_MODE_WS_DSP     (0x20)
 
-#define I2S_MODE_PHILLIPS   (I2S_MODE_SCK_POL | I2S_MODE_LR_ALIGN)
-#define I2S_MODE_RJ         (I2S_MODE_SCK_POL | I2S_MODE_WS_POL | \
-			     I2S_MODE_SAMPLE_DEL)
-#define I2S_MODE_LJ         (I2S_MODE_SCK_POL | I2S_MODE_WS_POL | \
-			     I2S_MODE_LR_ALIGN | I2S_MODE_SAMPLE_DEL)
-#define I2S_MODE_DSP        (I2S_MODE_SCK_POL | I2S_MODE_LR_ALIGN | \
-			     I2S_MODE_WS_DSP)
+#define I2S_MODE_PHILLIPS   (I2S_MODE_LR_ALIGN)
+#define I2S_MODE_RJ         (I2S_MODE_WS_POL | I2S_MODE_SAMPLE_DEL)
+#define I2S_MODE_LJ         (I2S_MODE_WS_POL | I2S_MODE_LR_ALIGN | I2S_MODE_SAMPLE_DEL)
+#define I2S_MODE_DSP        (I2S_MODE_LR_ALIGN | I2S_MODE_WS_DSP)
 
 // I2S configuration object
 struct soc_i2s_cfg {


### PR DESCRIPTION
It is incorrectly set to one, table 195 in the data sheet states it should be zero. The non-DMA I2S library also has the bit set to 0.


<img width="514" alt="screen shot 2016-09-29 at 5 34 08 pm" src="https://cloud.githubusercontent.com/assets/1163840/18973340/01d05c0c-866b-11e6-9b64-cb8c28240f93.png">