### PR TITLE
Make g_APinDescription const

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -60,7 +60,7 @@ typedef void (*voidFuncPtr)( void ) ;
 
 /* Types used for the tables below */
 /* TODO - consider using smaller types to optimise storage space */
-typedef struct _PinDescription
+typedef const struct _PinDescription
 {
         uint32_t                ulGPIOId;               // GPIO port pin
         uint32_t                ulGPIOPort;             // GPIO port ID

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -97,16 +97,13 @@ void analogWrite(uint8_t pin, int val)
         offset = ((p->ulPwmChan * QRK_PWM_N_REGS_LEN) + QRK_PWM_N_LOAD_COUNT1);
         MMIO_REG_VAL(QRK_PWM_BASE_ADDR + offset) = lcnt;
 
-        if (p->ulPinMode != PWM_MUX_MODE) {
-            /* start the PWM output */
-            offset = ((p->ulPwmChan * QRK_PWM_N_REGS_LEN) + QRK_PWM_N_CONTROL);
-            SET_MMIO_MASK(QRK_PWM_BASE_ADDR + offset, QRK_PWM_CONTROL_ENABLE);
+        /* start the PWM output */
+        offset = ((p->ulPwmChan * QRK_PWM_N_REGS_LEN) + QRK_PWM_N_CONTROL);
+        SET_MMIO_MASK(QRK_PWM_BASE_ADDR + offset, QRK_PWM_CONTROL_ENABLE);
 
-            /* Disable pull-up and set pin mux for PWM output */
-            SET_PIN_PULLUP(p->ulSocPin, 0);
-            SET_PIN_MODE(p->ulSocPin, PWM_MUX_MODE);
-            p->ulPinMode = PWM_MUX_MODE;
-        }
+        /* Disable pull-up and set pin mux for PWM output */
+        SET_PIN_PULLUP(p->ulSocPin, 0);
+        SET_PIN_MODE(p->ulSocPin, PWM_MUX_MODE);
     }
 }
 uint32_t analogRead(uint32_t pin)
@@ -120,11 +117,8 @@ uint32_t analogRead(uint32_t pin)
     PinDescription *p = &g_APinDescription[pin];
 
     /* Disable pull-up and set pin mux for ADC output */
-    if (p->ulPinMode != ADC_MUX_MODE) {
-       SET_PIN_MODE(p->ulSocPin, ADC_MUX_MODE);
-       p->ulPinMode = ADC_MUX_MODE;
-       SET_PIN_PULLUP(p->ulSocPin,0);
-    }
+    SET_PIN_MODE(p->ulSocPin, ADC_MUX_MODE);
+    SET_PIN_PULLUP(p->ulSocPin,0);
 
     /* Reset sequence pointer */
     SET_ARC_MASK(ADC_CTRL, ADC_SEQ_PTR_RST);

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -31,7 +31,6 @@ void pinMode( uint8_t pin, uint8_t mode )
     PinDescription *p = &g_APinDescription[pin];
 
     if (mode == OUTPUT) {
-        p->ulInputMode = OUTPUT_MODE;
         if (p->ulGPIOType == SS_GPIO) {
             uint32_t reg = p->ulGPIOBase + SS_GPIO_SWPORTA_DDR;
             SET_ARC_BIT(reg, p->ulGPIOId);
@@ -41,7 +40,6 @@ void pinMode( uint8_t pin, uint8_t mode )
             SET_MMIO_BIT(reg, p->ulGPIOId);
         }
     } else {
-        p->ulInputMode = INPUT_MODE;
         if (p->ulGPIOType == SS_GPIO) {
             uint32_t reg = p->ulGPIOBase + SS_GPIO_SWPORTA_DDR;
             CLEAR_ARC_BIT(reg, p->ulGPIOId);
@@ -54,10 +52,7 @@ void pinMode( uint8_t pin, uint8_t mode )
 
     /* Set SoC pin mux configuration */
     SET_PIN_PULLUP(p->ulSocPin, (mode == INPUT_PULLUP) ? 1 : 0);
-    if (p->ulPinMode != GPIO_MUX_MODE) {
-        SET_PIN_MODE(p->ulSocPin, GPIO_MUX_MODE);
-        p->ulPinMode = GPIO_MUX_MODE;
-    }
+    SET_PIN_MODE(p->ulSocPin, GPIO_MUX_MODE);
 }
 
 void digitalWrite( uint8_t pin, uint8_t val )
@@ -66,27 +61,25 @@ void digitalWrite( uint8_t pin, uint8_t val )
 	
     PinDescription *p = &g_APinDescription[pin];
 
-    if (!p->ulInputMode) {
-        if (p->ulGPIOType == SS_GPIO) {
-            uint32_t reg = p->ulGPIOBase + SS_GPIO_SWPORTA_DR;
-            if (val)
-                SET_ARC_BIT(reg, p->ulGPIOId);
-            else
-                CLEAR_ARC_BIT(reg, p->ulGPIOId);
-        }
-        else if (p->ulGPIOType == SOC_GPIO) {
-            uint32_t reg = p->ulGPIOBase + SOC_GPIO_SWPORTA_DR;
-            if (val)
-                SET_MMIO_BIT(reg, p->ulGPIOId);
-            else
-                CLEAR_MMIO_BIT(reg, p->ulGPIOId);
-        }
-    } else {
-        if (val)
-            SET_PIN_PULLUP(p->ulSocPin,1);
-        else
-            SET_PIN_PULLUP(p->ulSocPin,0);
-    }
+	if (p->ulGPIOType == SS_GPIO) {
+		uint32_t reg = p->ulGPIOBase + SS_GPIO_SWPORTA_DR;
+		if (val)
+			SET_ARC_BIT(reg, p->ulGPIOId);
+		else
+			CLEAR_ARC_BIT(reg, p->ulGPIOId);
+	}
+	else if (p->ulGPIOType == SOC_GPIO) {
+		uint32_t reg = p->ulGPIOBase + SOC_GPIO_SWPORTA_DR;
+		if (val)
+			SET_MMIO_BIT(reg, p->ulGPIOId);
+		else
+			CLEAR_MMIO_BIT(reg, p->ulGPIOId);
+	}
+
+	if (val)
+		SET_PIN_PULLUP(p->ulSocPin,1);
+	else
+		SET_PIN_PULLUP(p->ulSocPin,0);
 }
 
 int digitalRead( uint8_t pin )

--- a/libraries/CurieI2S/src/CurieI2S.cpp
+++ b/libraries/CurieI2S/src/CurieI2S.cpp
@@ -419,9 +419,6 @@ void Curie_I2S::muxRX(bool enable)
     SET_PIN_MODE(49, mux_mode); //I2S_RXD
     SET_PIN_MODE(51, mux_mode); //I2S_RWS
     SET_PIN_MODE(50,  mux_mode); //I2S_RSCK
-    g_APinDescription[I2S_RXD].ulPinMode = mux_mode;
-    g_APinDescription[I2S_RWS].ulPinMode = mux_mode;
-    g_APinDescription[I2S_RSCK].ulPinMode  = mux_mode;
 }
 
 void Curie_I2S::muxTX(bool enable)
@@ -436,9 +433,6 @@ void Curie_I2S::muxTX(bool enable)
     SET_PIN_MODE(g_APinDescription[I2S_TXD].ulSocPin, mux_mode);
     SET_PIN_MODE(g_APinDescription[I2S_TWS].ulSocPin, mux_mode);
     SET_PIN_MODE(g_APinDescription[I2S_TSCK].ulSocPin,  mux_mode);
-    g_APinDescription[I2S_TXD].ulPinMode = mux_mode;
-    g_APinDescription[I2S_TWS].ulPinMode = mux_mode;
-    g_APinDescription[I2S_TSCK].ulPinMode  = mux_mode;
 }
 
 void Curie_I2S::initRX()

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -94,9 +94,6 @@ void SPIClass::begin()
         SET_PIN_MODE(g_APinDescription[MOSI].ulSocPin, SPI_MUX_MODE);
         SET_PIN_MODE(g_APinDescription[MISO].ulSocPin, SPI_MUX_MODE);
         SET_PIN_MODE(g_APinDescription[SCK].ulSocPin,  SPI_MUX_MODE);
-        g_APinDescription[MOSI].ulPinMode = SPI_MUX_MODE;
-        g_APinDescription[MISO].ulPinMode = SPI_MUX_MODE;
-        g_APinDescription[SCK].ulPinMode  = SPI_MUX_MODE;
 
     }
     initialized++; /* reference count */


### PR DESCRIPTION
This has the effect of moving g_APinDescription out of .data (SRAM),
and into .rodata (flash).

Pros:
sketches now have an additional 1160 bytes of SRAM available

Cons:
state of pins is no longer tracked; e.g. when calling digitalWrite,
the full configuration is done each time. See changes in wiring_digital.c
and wiring_analog.c for details. There is inevitably a performance impact
for digitalRead/Write & analogRead/Write, though it is unlikely to be a
noticable one.

@calvinatintel @bigdinotech @SidLeung @russmcinnis @noelpaz please review.

**Do not merge until it is explicitly requested**