### PR TITLE
CurieMailbox: Use ints for public function parameters

### DIFF
--- a/libraries/CurieMailbox/src/CurieMailbox.cpp
+++ b/libraries/CurieMailbox/src/CurieMailbox.cpp
@@ -12,7 +12,7 @@
 #define CHANNEL_STS_BITS            (CHANNEL_STS_MASK | CHANNEL_INT_MASK)
 
 #define CAP_CHAN(chan)              chan = (chan >= NUM_CHANNELS) ? \
-                                    NUM_CHANNELS - 1 : chan
+                                    NUM_CHANNELS - 1 : ((chan < 0) ? 0 : chan)
 
 /* Mailbox channel status register */
 #define IO_REG_MAILBOX_CHALL_STS    (SCSS_REGISTER_BASE + 0xAC0)
@@ -158,13 +158,13 @@ int CurieMailboxClass::available (void)
     return ((head + BUFSIZE) - tail) % BUFSIZE;
 }
 
-void CurieMailboxClass::enableReceive (unsigned int channel)
+void CurieMailboxClass::enableReceive (int channel)
 {
     CAP_CHAN(channel);
     intmask->ss_intmask &= ~(1 << channel);
 }
 
-void CurieMailboxClass::disableReceive (unsigned int channel)
+void CurieMailboxClass::disableReceive (int channel)
 {
     CAP_CHAN(channel);
     intmask->ss_intmask |= 1 << channel;
@@ -191,10 +191,7 @@ void CurieMailboxClass::end (void)
 
 void CurieMailboxClass::put (CurieMailboxMsg msg)
 {
-    if (msg.channel > (NUM_CHANNELS - 1)) {
-        msg.channel = NUM_CHANNELS - 1;
-    }
-
+    CAP_CHAN(msg.channel);
     write_channel(msg);
 }
 

--- a/libraries/CurieMailbox/src/CurieMailbox.h
+++ b/libraries/CurieMailbox/src/CurieMailbox.h
@@ -10,8 +10,8 @@ public:
     void begin (bool master);
     void end (void);
 
-    void enableReceive (unsigned int channel);
-    void disableReceive (unsigned int channel);
+    void enableReceive (int channel);
+    void disableReceive (int channel);
 
     int available (void);
     void put (CurieMailboxMsg msg);

--- a/libraries/CurieMailbox/src/CurieMailboxMsg.h
+++ b/libraries/CurieMailbox/src/CurieMailboxMsg.h
@@ -7,7 +7,7 @@ class CurieMailboxMsg {
 public:
     uint32_t data[CHANNEL_DATA_WORDS];
     uint32_t id;
-    unsigned int channel = 0;
+    int channel = 0;
 };
 
 #endif


### PR DESCRIPTION
Arduino users are more comfortable with ints. Use ints instead of
'unsigned' or 'uint*', and the extra check for non-negativity, wherever
possible.

@bigdinotech @SidLeung please review.