### PR TITLE
Add CODK Makefile to CurieMailbox examples

### DIFF
--- a/libraries/CurieMailbox/examples/SharedCounter/Makefile
+++ b/libraries/CurieMailbox/examples/SharedCounter/Makefile
@@ -1,0 +1,17 @@
+ifeq ("$(strip $(CODK_DIR))", "")
+  $(error Please set the CODK_DIR variable.)
+endif
+
+ARDUINOSW_DIR ?= $(CODK_DIR)/arc
+
+current_dir = $(shell pwd)
+
+VERBOSE  = true
+
+LIBDIRS  = $(ARDUINOSW_DIR)/corelibs/libraries/CurieMailbox/src
+
+include $(ARDUINOSW_DIR)/Makefile.inc
+
+all: compile
+
+.DEFAULT_GOAL := all

--- a/libraries/CurieMailbox/examples/String/Makefile
+++ b/libraries/CurieMailbox/examples/String/Makefile
@@ -1,0 +1,17 @@
+ifeq ("$(strip $(CODK_DIR))", "")
+  $(error Please set the CODK_DIR variable.)
+endif
+
+ARDUINOSW_DIR ?= $(CODK_DIR)/arc
+
+current_dir = $(shell pwd)
+
+VERBOSE  = true
+
+LIBDIRS  = $(ARDUINOSW_DIR)/corelibs/libraries/CurieMailbox/src
+
+include $(ARDUINOSW_DIR)/Makefile.inc
+
+all: compile
+
+.DEFAULT_GOAL := all


### PR DESCRIPTION
This allows the examples to be used immediately in CODK-M, without
editing any Makefiles.

@bigdinotech @SidLeung @calvinatintel please review