### PR TITLE
Add functions to check if new IMU data is available

### DIFF
--- a/libraries/CurieIMU/src/BMI160.cpp
+++ b/libraries/CurieIMU/src/BMI160.cpp
@@ -2386,3 +2386,19 @@ uint8_t BMI160Class::getRegister(uint8_t reg) {
 void BMI160Class::setRegister(uint8_t reg, uint8_t data) {
     reg_write(reg, data);
 }
+
+/** Check if new gyroscope data is available
+ * @return True if new data is available, else false.
+ */
+bool BMI160Class::gyroDataReady()
+{
+    return reg_read_bits(BMI160_RA_STATUS, BMI160_STATUS_DRDY_GYR, 1);
+}
+
+/** Check if new accelerometer data is available
+ * @return True if new data is available, else false.
+ */
+bool BMI160Class::accelDataReady()
+{
+    return reg_read_bits(BMI160_RA_STATUS, BMI160_STATUS_DRDY_ACC, 1);
+}

--- a/libraries/CurieIMU/src/BMI160.h
+++ b/libraries/CurieIMU/src/BMI160.h
@@ -653,6 +653,9 @@ class BMI160Class {
         void setInterruptLatch(uint8_t latch);
         void resetInterrupt();
 
+        bool gyroDataReady();
+        bool accelDataReady();
+
     protected:
         virtual int serial_buffer_transfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
 


### PR DESCRIPTION
accelDataReady() and gyroDataReady() read the drdy_acc and drdy_gyr
bits, respectively, of the BMI160's sensor status register. This removes
the burden of syncronising sensor reads from the user.

(adapted from descampsa/corelibs-arduino101@773a800)

@bigdinotech @calvinatintel @SidLeung please review.
Don't merge this. I'm gonna do some testing and I'll merge it when that's done.