### PR TITLE
I2SDMA: Do not modify g_APinDescription

### DIFF
--- a/libraries/CurieI2S/src/CurieI2SDMA.cpp
+++ b/libraries/CurieI2S/src/CurieI2SDMA.cpp
@@ -110,9 +110,6 @@ void Curie_I2SDMA::muxTX(bool enable)
 	SET_PIN_MODE(g_APinDescription[I2S_TXD].ulSocPin, mux_mode);
 	SET_PIN_MODE(g_APinDescription[I2S_TWS].ulSocPin, mux_mode);
 	SET_PIN_MODE(g_APinDescription[I2S_TSCK].ulSocPin, mux_mode);
-	g_APinDescription[I2S_TXD].ulPinMode = mux_mode;
-	g_APinDescription[I2S_TWS].ulPinMode = mux_mode;
-	g_APinDescription[I2S_TSCK].ulPinMode  = mux_mode;
 }
 
 void Curie_I2SDMA::muxRX(bool enable)
@@ -127,9 +124,6 @@ void Curie_I2SDMA::muxRX(bool enable)
 	SET_PIN_MODE(49, mux_mode); //I2S_RXD
 	SET_PIN_MODE(51, mux_mode); //I2S_RWS
 	SET_PIN_MODE(50,  mux_mode); //I2S_RSCK
-	g_APinDescription[I2S_RXD].ulPinMode = mux_mode;
-	g_APinDescription[I2S_RWS].ulPinMode = mux_mode;
-	g_APinDescription[I2S_RSCK].ulPinMode  = mux_mode;
 }
 
 int Curie_I2SDMA::beginTX(uint16_t sample_rate,uint8_t resolution,uint8_t master,uint8_t mode)


### PR DESCRIPTION
The g_APinDesctiption is now 'const', so cannot be modified.

@bigdinotech please review