### PR TITLE
Allocate RingBuffer buffer into DCCM area

### DIFF
--- a/cores/arduino/RingBuffer.cpp
+++ b/cores/arduino/RingBuffer.cpp
@@ -23,6 +23,7 @@
 
 RingBuffer::RingBuffer( void )
 {
+    _aucBuffer = (uint8_t*)dccm_malloc(UART_BUFFER_SIZE);
     memset( _aucBuffer, 0, UART_BUFFER_SIZE ) ;
     _iHead=0 ;
     _iTail=0 ;

--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -18,6 +18,7 @@
 #define _RING_BUFFER_
 
 #include <stdint.h>
+#include "dccm/dccm_alloc.h"
 
 // Define constants and variables for buffering incoming serial data.  We're
 // using a ring buffer (I think), in which head is the index of the location
@@ -28,7 +29,7 @@
 class RingBuffer
 {
 public:
-	uint8_t _aucBuffer[UART_BUFFER_SIZE] ;
+	uint8_t *_aucBuffer;
 	int _iHead ;
 	int _iTail ;
 	bool _buffer_overflow ;


### PR DESCRIPTION
-this buffer is used by the uart. Moving it into the DCCM area would
save us 128 bytes of SRAM