### PR TITLE
README.md: remove Serial1 debug information

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,3 @@ them to the [support forum](https://forum.arduino.cc/index.php?board=103).
 > "How do I use this library?"
 
 > "I can't get this example sketch to work. What am I doing wrong?"
-
-# Enable debug interface on Serail1
-
-* Default disable the debug interface.
-
-If you want to enable debug trace on Serial1 to debug corelib,  follow these instructions.
-
-1. Shut down the IDE
-2. Go to Arduino15 directory
-  * Windows: `C:\Users\<user>\AppData\Roaming\Arduino15`
-  * OS X: `~/Library/Arduino15`
-  * Linux: `~/.arduino15`
-3. Modify the platform.txt
-  * Find `compiler.c.flags` and add `-DCONFIGURE_DEBUG_CORELIB_ENABLED` at the end of this line
-  * Find `compiler.cpp.flags` and add `-DCONFIGURE_DEBUG_CORELIB_ENABLED` at the end of this line
-4. Initial Serial1 in your sketch
-  * Add `Serial1.begin(115200);` in your `setup()`
-5. Adjust the output level at log_init function in log.c

--- a/libraries/CurieBLE/README.md
+++ b/libraries/CurieBLE/README.md
@@ -1,0 +1,18 @@
+# Enable debug interface on Serail1
+
+* Default disable the debug interface.
+
+If you want to enable debug trace on Serial1 to debug corelib,  follow these instructions.
+
+1. Shut down the IDE
+2. Go to Arduino15 directory
+  * Windows: `C:\Users\<user>\AppData\Roaming\Arduino15`
+  * OS X: `~/Library/Arduino15`
+  * Linux: `~/.arduino15`
+3. Modify the platform.txt
+  * Find `compiler.c.flags` and add `-DCONFIGURE_DEBUG_CORELIB_ENABLED` at the end of this line
+  * Find `compiler.cpp.flags` and add `-DCONFIGURE_DEBUG_CORELIB_ENABLED` at the end of this line
+4. Initial Serial1 in your sketch
+  * Add `Serial1.begin(115200);` in your `setup()`
+5. Adjust the output level at log_init function in log.c
+


### PR DESCRIPTION
@SidLeung this was added with the big BLE commit (ae78b162), but I'm not sure if we need it in the corelibs README. What do you think?
