### PR TITLE
check mux mode when using digitalWrite

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <math.h>
 
+#include "pins_arduino.h"
+
 #include "binary.h"
 //#include "itoa.h"
 
@@ -96,6 +98,8 @@ typedef struct _PinDescription
 extern PinDescription g_APinDescription[] ;
 
 extern uint32_t pwmPeriod[4];
+
+extern uint8_t pinmuxMode[NUM_DIGITAL_PINS];
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -93,10 +93,14 @@ void analogWrite(uint8_t pin, uint32_t val)
         /* start the PWM output */
         offset = ((p->ulPwmChan * QRK_PWM_N_REGS_LEN) + QRK_PWM_N_CONTROL);
         SET_MMIO_MASK(QRK_PWM_BASE_ADDR + offset, QRK_PWM_CONTROL_ENABLE);
-
-        /* Disable pull-up and set pin mux for PWM output */
-        SET_PIN_PULLUP(p->ulSocPin, 0);
-        SET_PIN_MODE(p->ulSocPin, PWM_MUX_MODE);
+        
+        if(pinmuxMode[pin] != PWM_MUX_MODE)
+        {
+            /* Disable pull-up and set pin mux for PWM output */
+            SET_PIN_PULLUP(p->ulSocPin, 0);
+            SET_PIN_MODE(p->ulSocPin, PWM_MUX_MODE);
+            pinmuxMode[pin] = PWM_MUX_MODE;
+        }
     }
 }
 uint32_t analogRead(uint32_t pin)

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -53,6 +53,10 @@ void pinMode( uint8_t pin, uint8_t mode )
     /* Set SoC pin mux configuration */
     SET_PIN_PULLUP(p->ulSocPin, (mode == INPUT_PULLUP) ? 1 : 0);
     SET_PIN_MODE(p->ulSocPin, GPIO_MUX_MODE);
+    if(pinmuxMode[pin] != GPIO_MUX_MODE)
+    {
+        pinmuxMode[pin] = GPIO_MUX_MODE;
+    }
 }
 
 void digitalWrite( uint8_t pin, uint8_t val )
@@ -60,7 +64,13 @@ void digitalWrite( uint8_t pin, uint8_t val )
     if (pin >= NUM_DIGITAL_PINS) return;
 	
     PinDescription *p = &g_APinDescription[pin];
-
+    
+    if(pinmuxMode[pin] != GPIO_MUX_MODE)
+    {
+        pinmuxMode[pin] = GPIO_MUX_MODE;
+        SET_PIN_MODE(p->ulSocPin, GPIO_MUX_MODE);
+    }
+    
 	if (p->ulGPIOType == SS_GPIO) {
 		uint32_t reg = p->ulGPIOBase + SS_GPIO_SWPORTA_DR;
 		if (val)

--- a/libraries/CurieSoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/CurieSoftwareSerial/src/SoftwareSerial.cpp
@@ -280,8 +280,8 @@ void SoftwareSerial::begin(long speed)
   {
     _isSOCGpio = true;
   }
-  //toggling a pin takes about 62 ticks
-  _tx_delay = _bit_delay - 62;
+  //toggling a pin takes about 68 ticks
+  _tx_delay = _bit_delay - 68;
   //reading a pin takes about 70 ticks
   _rx_delay_intrabit = _bit_delay - 70;
   //it takes about 272 ticks from when the start bit is received to when the ISR is called

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -94,7 +94,9 @@ void SPIClass::begin()
         SET_PIN_MODE(g_APinDescription[MOSI].ulSocPin, SPI_MUX_MODE);
         SET_PIN_MODE(g_APinDescription[MISO].ulSocPin, SPI_MUX_MODE);
         SET_PIN_MODE(g_APinDescription[SCK].ulSocPin,  SPI_MUX_MODE);
-
+        pinmuxMode[MISO] = SPI_MUX_MODE;
+        pinmuxMode[MOSI] = SPI_MUX_MODE;
+        pinmuxMode[SCK] = SPI_MUX_MODE;
     }
     initialized++; /* reference count */
     interrupt_unlock(flags);

--- a/variants/arduino_101/variant.cpp
+++ b/variants/arduino_101/variant.cpp
@@ -99,6 +99,8 @@ PinDescription g_APinDescription[]=
 } ;
 
 uint32_t pwmPeriod[] = {PWM_PERIOD, PWM_PERIOD/2, PWM_PERIOD/2, PWM_PERIOD};
+
+uint8_t pinmuxMode[];
 #ifdef __cplusplus
 }
 #endif
@@ -173,6 +175,7 @@ void variantGpioInit(void)
     for (uint8_t pin = 0; pin < NUM_DIGITAL_PINS; pin++) {
         PinDescription *p = &g_APinDescription[pin];
         SET_PIN_MODE(p->ulSocPin, p->ulPinMode);
+        pinmuxMode[pin] = GPIO_MUX_MODE;
     }
 }
 


### PR DESCRIPTION
-check and make sure that the pin is in GPIO_MUX_MODE when doing a
digitalWrite()
-this has a slight performance impact of digitalWrite
-it also comsumes an extra byte in SRAM per pin
-it does however give us the ability to track the muxing state of each
pin
