### PR TITLE
Ensure RTC clock scaling is set to 1Hz

### DIFF
--- a/variants/arduino_101/variant.cpp
+++ b/variants/arduino_101/variant.cpp
@@ -240,7 +240,12 @@ void initVariant( void )
     variantGpioInit();
     variantPwmInit();
     variantAdcInit();
-
+    
+    //set RTC clock divider to 32768(1 Hz)
+    *SYS_CLK_CTL |= RTC_DIV_1HZ_MASK;
+    *SYS_CLK_CTL &= ~(1 << CCU_RTC_CLK_DIV_EN);
+    *SYS_CLK_CTL |= 1 << CCU_RTC_CLK_DIV_EN;
+    
     cfw_platform_init();
     
     // Add for debug corelib

--- a/variants/arduino_101/variant.h
+++ b/variants/arduino_101/variant.h
@@ -146,6 +146,14 @@ extern "C"{
 #define ADC_RESOLUTION               12
 #define ADC_CLOCK_GATE             (1 << 31)
 
+/*
+ * Clocking
+ */
+ 
+#define SYS_CLK_CTL         (volatile int*)0xB0800038
+#define CCU_RTC_CLK_DIV_EN  2
+#define RTC_DIV_1HZ_MASK    0x00000078         
+
 #define digitalPinToBitMask(P)     (1 << g_APinDescription[P].ulGPIOId)
 
 //static uint8_t __unused_var_POR;


### PR DESCRIPTION
-needed to make sure that the RTC scaling is consitent with the factory
firmware and CODK-M based firmware