### PR TITLE
CurieMailbox/examples/String.ino: receive on all channels

### DIFF
--- a/libraries/CurieMailbox/examples/String/String.ino
+++ b/libraries/CurieMailbox/examples/String/String.ino
@@ -15,23 +15,23 @@
 
 #include "CurieMailbox.h"
 
-int receiveChannel = 0;  /* Receiving messages on this channel */
-
 void setup (void) {
     Serial.begin(9600);
 
     /* Enable the mailbox */
     CurieMailbox.begin();
 
-    /* Enable channel for receiving messages */
-    CurieMailbox.enableReceive(receiveChannel);
+    /* Enable all channels for receiving messages */
+    for (int i = 0; i < CurieMailbox.numChannels; ++i) {
+        CurieMailbox.enableReceive(i);
+    }
 }
 
 void printMessageAsString (CurieMailboxMsg msg)
 {
     char *p = (char *)msg.data;
-    Serial.print("Received message '" + String(p) + "' from channel ");
-    Serial.println(msg.channel);
+    Serial.print("Received message from channel " + String(msg.channel) + ": ");
+    Serial.println(String(p));
 }
 
 void loop (void) {

--- a/libraries/CurieMailbox/src/CurieMailbox.cpp
+++ b/libraries/CurieMailbox/src/CurieMailbox.cpp
@@ -4,15 +4,15 @@
 #include "CurieMailbox.h"
 
 #define BUFSIZE                     33
-#define NUM_CHANNELS                8
 #define CHANNEL_STS_MASK            0x1
 #define CHANNEL_INT_MASK            0x2
 #define CTRL_WORD_MASK              0x7FFFFFFF
 #define CHALL_STATUS_MASK           0xFFFF
 #define CHANNEL_STS_BITS            (CHANNEL_STS_MASK | CHANNEL_INT_MASK)
 
-#define CAP_CHAN(chan)              chan = (chan >= NUM_CHANNELS) ? \
-                                    NUM_CHANNELS - 1 : ((chan < 0) ? 0 : chan)
+#define CAP_CHAN(chan)              chan = (chan >= CurieMailbox.numChannels) ?\
+                                    CurieMailbox.numChannels - 1 : ((chan < 0) \
+                                    ? 0 : chan)
 
 /* Mailbox channel status register */
 #define IO_REG_MAILBOX_CHALL_STS    (SCSS_REGISTER_BASE + 0xAC0)
@@ -122,7 +122,7 @@ static void mbox_isr (void)
 
     sts = get_chall_sts();
     /* Get channel number */
-    for (i = 0; i < NUM_CHANNELS; ++i) {
+    for (i = 0; i < CurieMailbox.numChannels; ++i) {
         if (sts & (1 << (i * 2 + 1))) {
             break;
         }
@@ -135,7 +135,7 @@ static void mbox_hardware_init (void)
 {
     int i;
 
-    for (i = 0; i < NUM_CHANNELS; ++i) {
+    for (i = 0; i < CurieMailbox.numChannels; ++i) {
         mbox[i].sts &= ~(CHANNEL_STS_BITS);
     }
 }

--- a/libraries/CurieMailbox/src/CurieMailbox.h
+++ b/libraries/CurieMailbox/src/CurieMailbox.h
@@ -5,6 +5,8 @@
 
 class CurieMailboxClass {
 public:
+    const int numChannels = 8;
+
     CurieMailboxClass (void);
     void begin (void);
     void begin (bool master);


### PR DESCRIPTION
Also, add public 'numChannels' constant to CurieMailbox class, so all
channels can be easily iterated over.

These changes allow us to demonstrate how to iterate over all the mailbox channels in the String.ino example

@bigdinotech @SidLeung please review