### PR TITLE
I2S example sketches failed compliation, Jira 786.

### DIFF
--- a/libraries/CurieI2S/examples/I2SDMA_RXCallBack/I2SDMA_RXCallBack.ino
+++ b/libraries/CurieI2S/examples/I2SDMA_RXCallBack/I2SDMA_RXCallBack.ino
@@ -22,8 +22,8 @@
 **/
 #include <CurieI2SDMA.h>
 
-#define BUFF_SIZE 128
-#define OFFSET 2
+const int BUFF_SIZE=64;
+const int OFFSET=2;
 uint32_t dataBuff[BUFF_SIZE+OFFSET]; // extra 2 buffers are for the padding zero
 
 /** 

--- a/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
+++ b/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
@@ -9,7 +9,7 @@
 
 #include <CurieI2SDMA.h>
 
-#define BUFF_SIZE 128
+const int BUFF_SIZE=64;
 boolean blinkState = true;          // state of the LED
 uint32_t dataBuff[BUFF_SIZE];
 uint32_t loop_count = 0;

--- a/libraries/CurieI2S/examples/I2S_RxCallback/I2S_RxCallback.ino
+++ b/libraries/CurieI2S/examples/I2S_RxCallback/I2S_RxCallback.ino
@@ -17,7 +17,9 @@
 **/
 #include <CurieI2S.h>
 
-uint32_t dataBuff[256];
+const int BUFF_SIZE=128;
+
+uint32_t dataBuff[BUFF_SIZE];
 volatile int count = 0;
 
 void setup() 
@@ -54,6 +56,6 @@ void rxDataReceived()
   while(CurieI2S.available())
   {
     dataBuff[count++] =  CurieI2S.requestdword();   
-    count %= 256; //prevent buffer overflow and just write data in front of the buffer.
+    count %= BUFF_SIZE; //prevent buffer overflow and just write data in front of the buffer.
   }
 }


### PR DESCRIPTION
The latest BLE library consumes more heap space that causes these sketches ran out of heap space for their temporary
buffers.  For now, the size of the tempporary is reduced.  For the near future, there are 3 improvements to address
this issue.  The BLE library will be making use of the DCCM memory instead of heap.  The I2S library buffering space
is going to the DCCM memory too.  The heap space will be increased to maximize the usage of the entire SRAM sapce.