### PR TITLE
CurieIMU.cpp: initialize saved accel/gyro ranges in begin()

### DIFF
--- a/libraries/CurieIMU/src/CurieIMU.cpp
+++ b/libraries/CurieIMU/src/CurieIMU.cpp
@@ -47,7 +47,12 @@ bool CurieIMUClass::begin()
      * MakgetGyroRatee sure the device is connected and responds as expected.
      * @return True if connection is valid, false otherwise
      */
-    return (CURIE_IMU_CHIP_ID == getDeviceID());
+    if (CURIE_IMU_CHIP_ID != getDeviceID())
+        return false;
+
+    accel_range = (float) getAccelerometerRange();
+    gyro_range = (float) getGyroRange();
+    return true;
 }
 
 void CurieIMUClass::end()


### PR DESCRIPTION
This ensures that "read[Accelerometer/Gyro]Scaled()" will work as
expected even if a range has not been explicitly set using the API

@russmcinnis to verify