### PR TITLE
Jira794 Central writeInt API behaves differently when use on various …

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -223,4 +223,8 @@ void ble_central_device_found(const bt_addr_le_t *addr,
                                                   ad, len);
 }
 
+void ble_on_write_no_rsp_complete(struct bt_conn *conn, uint8_t err,
+                                         const void *data)
+{
+}
 

--- a/libraries/CurieBLE/src/internal/BLECallbacks.h
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.h
@@ -74,5 +74,8 @@ uint8_t profile_service_read_rsp_process(bt_conn_t *conn,
                                  const void *data, 
                                  uint16_t length);
 
+void ble_on_write_no_rsp_complete(struct bt_conn *conn, uint8_t err,
+                                         const void *data);
+
 #endif
 

--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
@@ -655,12 +655,25 @@ bool BLECharacteristicImp::write(const unsigned char value[],
         return false;
     }
     
-    // Send read request
-    retval = bt_gatt_write_without_response(conn, 
-                                            _value_handle,
-                                            value, 
-                                            length, 
-                                            false);
+    // Send write request
+    if (_gatt_chrc.properties | BT_GATT_CHRC_WRITE_WITHOUT_RESP)
+    {
+        retval = bt_gatt_write_without_response(conn, 
+                                                _value_handle,
+                                                value, 
+                                                length, 
+                                                false);
+    }
+    else if (_gatt_chrc.properties | BT_GATT_CHRC_WRITE)
+    {
+        retval = bt_gatt_write(conn, 
+                               _value_handle,
+                               0,
+                               value, 
+                               length, 
+                               ble_on_write_no_rsp_complete);
+        
+    }
     bt_conn_unref(conn);
     return (0 == retval);
 }


### PR DESCRIPTION
…Peripherals

1. Check the type and call the right functions
2. Changed files
    libraries/CurieBLE/src/internal/BLECallbacks.cpp - faked write response CB
    libraries/CurieBLE/src/internal/BLECallbacks.h
    libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp - update the call

Fix #385 