### PR TITLE
Jira 791: Sketch crash using both Firmata and BLE library, git #377

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -59,6 +59,16 @@ class BLEDevice
      */
     BLEDevice(const BLEDevice* bledevice);
     BLEDevice(const BLEDevice& bledevice);
+    /**
+     * @brief   The BLE device constructure
+     *
+     * @param[in]   bleaddress  BLE device address
+     *
+     * @return  none
+     *
+     * @note  none
+     */
+    BLEDevice(const bt_addr_le_t* bleaddress);
     virtual ~BLEDevice();
 
     
@@ -653,16 +663,6 @@ protected:
     void setAddress(const bt_addr_le_t& addr);
     
     void setAdvertiseData(const uint8_t* adv_data, uint8_t len);
-    /**
-     * @brief   The BLE device constructure
-     *
-     * @param[in]   bleaddress  BLE device address
-     *
-     * @return  none
-     *
-     * @note  none
-     */
-    BLEDevice(const bt_addr_le_t* bleaddress);
 private:
     void preCheckProfile();
     

--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -55,67 +55,37 @@ BLEPeripheral::~BLEPeripheral(void)
 
 void BLEPeripheral::setAdvertisedServiceUuid(const char* advertisedServiceUuid)
 {
-    if (!_initCalled) {
-        init();
-    }
-
     BLE.setAdvertisedServiceUuid(advertisedServiceUuid);
 }
+
 void BLEPeripheral::setLocalName(const char* localName)
 {
-    if (!_initCalled) {
-        init();
-    }
-
     BLE.setLocalName(localName);
 }
 
-
 void BLEPeripheral::setDeviceName(const char *deviceName)
 {
-    if (!_initCalled) {
-        init();
-    }
-
     BLE.setDeviceName(deviceName);
 }
 
 void BLEPeripheral::setAppearance(const unsigned short appearance)
 {
-    if (!_initCalled) {
-        init();
-    }
-
     BLE.setAppearance(appearance);
 }
 
 void BLEPeripheral::setConnectionInterval(const unsigned short minConnInterval, const unsigned short maxConnInterval)
 {
-    if (!_initCalled) {
-        init();
-    }
-
     BLE.setConnectionInterval(minConnInterval, maxConnInterval);
 }
 
 void BLEPeripheral::addAttribute(BLEService& service)
 {
-    if (!_initCalled)
-    {
-        init();
-    }
-    
     BLE.addService(service);
     _lastService = &service;
 }
 
 void BLEPeripheral::addAttribute(BLECharacteristic& characteristic)
 {
-    if (!_initCalled)
-    {
-        init();
-    }
-
     if (_lastService)
     {
         _lastService->addCharacteristic(characteristic);
@@ -125,11 +95,6 @@ void BLEPeripheral::addAttribute(BLECharacteristic& characteristic)
 
 void BLEPeripheral::addAttribute(BLEDescriptor& descriptor)
 {
-    if (!_initCalled)
-    {
-        init();
-    }
-
     if (_lastCharacteristic)
     {
         _lastCharacteristic->addDescriptor(descriptor);

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -97,11 +97,11 @@ BLEDeviceManager::~BLEDeviceManager()
 
 bool BLEDeviceManager::begin(BLEDevice *device)
 {
-    if (NULL == _local_ble && false == *device)
+    if (NULL == _local_ble)
     {
         _local_ble = device;
-        _local_ble->setAddress(_local_bda);
         bt_le_set_mac_address(_local_bda);
+        
         // Set device name    
         setDeviceName();
         _state = BLE_PERIPH_STATE_READY;
@@ -133,7 +133,8 @@ void BLEDeviceManager::poll()
 }
 
 void BLEDeviceManager::end()
-{}
+{
+}
 
 bool BLEDeviceManager::connected(const BLEDevice *device) const
 {
@@ -287,7 +288,10 @@ void BLEDeviceManager::setDeviceName(const char* deviceName)
         if (len > BLE_MAX_DEVICE_NAME)
             len = BLE_MAX_DEVICE_NAME;
         memcpy(_device_name, deviceName, len);
-        setDeviceName();
+        if (NULL != _local_ble)
+        {
+            setDeviceName();
+        }
     }
 }
 

--- a/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
@@ -25,7 +25,7 @@
 #include "BLECallbacks.h"
 #include "BLEUtils.h"
 
-BLEDevice BLE;
+BLEDevice BLE(BLEUtils::bleGetLoalAddress());
 
 BLEProfileManager* BLEProfileManager::_instance = NULL;
 


### PR DESCRIPTION
1. The BLEStream object adds profile when boot but the HW doesn't be
    initialized and makes APP crash.
2. Change the BLE initial process not depend on HW. Buffer the
    attributes if HW not initialized.
3. Changed files
    libraries/CurieBLE/src/BLEDevice.h - expose constructor
    libraries/CurieBLE/src/BLEPeripheral.cpp - not call HW init function
    libraries/CurieBLE/src/internal/BLEDeviceManager.cpp - change init order
    libraries/CurieBLE/src/internal/BLEProfileManager.cpp - change constructor