### PR TITLE
Jira #758, Add scan response support for central role, git 370

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -133,6 +133,17 @@ void BLEDevice::setManufacturerData(const unsigned char manufacturerData[],
     BLEDeviceManager::instance()->setManufacturerData(manufacturerData, manufacturerDataLength);
 }
 
+bool BLEDevice::getManufacturerData (unsigned char* manu_data, 
+                                     unsigned char& manu_data_len) const
+{
+    return BLEDeviceManager::instance()->getManufacturerData(this, manu_data, manu_data_len);
+}
+
+bool BLEDevice::hasManufacturerData() const
+{
+    return BLEDeviceManager::instance()->hasManufacturerData(this);
+}
+
 void BLEDevice::setLocalName(const char *localName)
 {
     BLEDeviceManager::instance()->setLocalName(localName);

--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -191,6 +191,11 @@ class BLEDevice
     void setManufacturerData(const unsigned char manufacturerData[], 
                              unsigned char manufacturerDataLength);
     
+    bool getManufacturerData (unsigned char* manu_data, 
+                              unsigned char& manu_data_len) const;
+    
+    bool hasManufacturerData() const;
+    
     /**
      * Set the local name that the BLE Peripheral Device advertises
      *


### PR DESCRIPTION
This code modification is to enable the processing of the Scan Response data when the BLE stack is operating in the Central mode.