### PR TITLE
Jira 794 Inconsistent writeInt() result with different Peripherals, g…

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -223,4 +223,9 @@ void ble_central_device_found(const bt_addr_le_t *addr,
                                                   ad, len);
 }
 
+void ble_on_write_no_rsp_complete(struct bt_conn *conn, uint8_t err,
+                                         const void *data)
+{
+    BLECharacteristicImp::writeResponseReceived(conn, err, data);
+}
 

--- a/libraries/CurieBLE/src/internal/BLECallbacks.h
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.h
@@ -74,5 +74,8 @@ uint8_t profile_service_read_rsp_process(bt_conn_t *conn,
                                  const void *data, 
                                  uint16_t length);
 
+void ble_on_write_no_rsp_complete(struct bt_conn *conn, uint8_t err,
+                                         const void *data);
+
 #endif
 

--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
@@ -168,6 +168,10 @@ public:
      */
     bool write(const unsigned char value[], 
                uint16_t length);
+    
+    static void writeResponseReceived(struct bt_conn *conn, 
+                                      uint8_t err,
+                                      const void *data);
 
     int descriptorCount() const;
     uint8_t discoverResponseProc(bt_conn_t *conn,
@@ -325,6 +329,7 @@ private:
     bool        _subscribed;
     
     bool _reading;
+    static volatile bool _gattc_writing;
     bt_gatt_read_params_t _read_params; // GATT read parameter
     
     typedef LinkNode<BLEDescriptorImp *>  BLEDescriptorLinkNodeHeader;


### PR DESCRIPTION
Root cause:
-  The function, BLECharacteristicImp::write(), did not check the
   characteristic property to determine if the caller requires
   a response.  It just treats all calls do not require a
   response.

Modifications:
1. libraries/CurieBLE/src/internal/BLECallbacks.cpp:
   - Added fake write response CB for write with no response call.
2. libraries/CurieBLE/src/internal/BLECallbacks.h:
   - Function definition added.
3. libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp:
   - In function write(), check the characteristic property to
     determine whether the call requires a response.