### PR TITLE
Jira 797, Central can scan with MAC address, git 376

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -275,6 +275,12 @@ void BLEDevice::scanForUuid(String uuid, bool withDuplicates)
     startScan(withDuplicates);
 }
 
+void BLEDevice::scanForAddress(String macaddr, bool withDuplicates)
+{
+    BLEDeviceManager::instance()->setAdvertiseCritical(macaddr.c_str());
+    startScan(withDuplicates);
+}
+
 void BLEDevice::stopScan()
 {
     BLEDeviceManager::instance()->stopScanning();

--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -420,8 +420,9 @@ class BLEDevice
      * @note   option to filter out duplicate addresses for Arduino.
      *          The current only support fileter duplicate mode.
      */
-    void scanForUuid(String uuid, bool withDuplicates); 
+    void scanForUuid(String uuid, bool withDuplicates);
     
+    void scanForAddress(String macaddr, bool withDuplicates = true);
     /**
      * @brief   Stop scanning for peripherals
      *

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -77,6 +77,7 @@ BLEDeviceManager::BLEDeviceManager():
     memset(_peer_adv_mill, 0, sizeof(_peer_adv_mill));
     memset(&_adv_accept_critical, 0, sizeof(_adv_accept_critical));
     memset(&_adv_critical_service_uuid, 0, sizeof(_adv_critical_service_uuid));
+    memset(&_adv_accept_device, 0, sizeof(_adv_accept_device));
     
     memset(_peer_peripheral, 0, sizeof(_peer_peripheral));
     memset(_peer_peripheral_adv_data, 0, sizeof(_peer_peripheral_adv_data));
@@ -562,6 +563,7 @@ bool BLEDeviceManager::stopScanning()
 void BLEDeviceManager::clearAdvertiseCritical()
 {
     memset(&_adv_accept_critical, 0, sizeof(_adv_accept_critical));
+    memset(&_adv_accept_device, 0, sizeof(_adv_accept_device));
     //memset(&_adv_critical_service_uuid, 0, sizeof(_adv_critical_service_uuid));
 }
 
@@ -596,6 +598,11 @@ void BLEDeviceManager::setAdvertiseCritical(BLEService& service)
     _adv_accept_critical.type = type;
     _adv_accept_critical.data_len = length;
     _adv_accept_critical.data = data;
+}
+
+void BLEDeviceManager::setAdvertiseCritical(const char* macaddress)
+{
+    BLEUtils::macAddressString2BT(macaddress, _adv_accept_device);
 }
 
 bool BLEDeviceManager::hasLocalName(const BLEDevice* device) const
@@ -1248,6 +1255,13 @@ void BLEDeviceManager::handleDeviceFound(const bt_addr_le_t *addr,
     if (type == BT_LE_ADV_IND || type == BT_LE_ADV_DIRECT_IND)
     {
         //pr_debug(LOG_MODULE_BLE, "%s-%d", __FUNCTION__, __LINE__);
+        // Filter address
+        if (BLEUtils::macAddressValid(_adv_accept_device) == true && 
+		   (memcmp(addr->val, _adv_accept_device.val, sizeof (addr->val)) != 0))
+        {
+            return;
+        }
+        
         while (data_len > 1)
         {
             uint8_t len = data[0];

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -305,6 +305,7 @@ class BLEDeviceManager
     void clearAdvertiseCritical();
     void setAdvertiseCritical(String name);
     void setAdvertiseCritical(BLEService& service);
+    void setAdvertiseCritical(const char* macaddress);
     bool startScanning(); // start scanning for peripherals
     bool startScanningWithDuplicates(); // start scanning for peripherals, and report all duplicates
     bool stopScanning(); // stop scanning for peripherals
@@ -378,6 +379,7 @@ private:
     bt_data_t   _adv_accept_critical;   // The filters for central device
     String  _adv_critical_local_name;
     bt_uuid_128_t _adv_critical_service_uuid;
+    bt_addr_le_t _adv_accept_device;
     
     bt_addr_le_t _wait_for_connect_peripheral;
     uint8_t    _wait_for_connect_peripheral_adv_data[BLE_MAX_ADV_SIZE];


### PR DESCRIPTION
New feature:
-  Add the capability for a Central to scan for a
   Peripheral using its MAC address.

Code Modifications:
-  Added the API for MAC address scanning.
-  For Device Manager, added provision for holding the
   MAC address of a Peripheral.
-  For scan discovery handler, added the checking
   for MAC address comparison, if MAC address scanning
   is requested.

File changes:

1. libraries/CurieBLE/src/BLEDevice.cpp:
   - Added API for MAC address scanning.
2. libraries/CurieBLE/src/BLEDevice.h:
   - API definition.
3. libraries/CurieBLE/src/internal/BLEDeviceManager.cpp:
   - Added provision for storing the MAC address.
   - Added MAC address comparison in the scan discovery
     handle if MAC address scanning is selected.
4. libraries/CurieBLE/src/internal/BLEDeviceManager.h:
   - Prototyping.