### PR TITLE
Use single dataReady() method, instead of accelDataReady/gyroDataReady

### DIFF
--- a/libraries/CurieIMU/keywords.txt
+++ b/libraries/CurieIMU/keywords.txt
@@ -14,6 +14,7 @@ CurieIMUClass	KEYWORD1
 
 begin	KEYWORD1
 
+dataReady   KEYWORD1
 getGyroRate	KEYWORD1
 setGyroRate	KEYWORD1
 getAccelerometerRate	KEYWORD1
@@ -83,6 +84,9 @@ CurieIMU	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
+
+ACCEL   LITERAL1
+GYRO    LITERAL1
 
 X_AXIS	LITERAL1
 Y_AXIS	LITERAL1

--- a/libraries/CurieIMU/src/BMI160.h
+++ b/libraries/CurieIMU/src/BMI160.h
@@ -267,6 +267,12 @@ THE SOFTWARE.
 
 #define BMI160_RA_CMD               0x7E
 
+/* Bit flags for selecting individual sensors */
+typedef enum {
+    GYRO = 0x1,
+    ACCEL = 0x2
+} CurieIMUSensor;
+
 /**
  * Interrupt Latch Mode options
  * @see setInterruptLatch()
@@ -471,9 +477,10 @@ typedef enum {
 
 class BMI160Class {
     public:
-        void initialize();
+        void initialize(unsigned int flags);
         bool testConnection();
 
+        bool isEnabled(unsigned int sensors);
         uint8_t getGyroRate();
         void setGyroRate(uint8_t rate);
 
@@ -487,9 +494,9 @@ class BMI160Class {
         void setAccelDLPFMode(uint8_t bandwidth);
 
         uint8_t getFullScaleGyroRange();
-        void setFullScaleGyroRange(uint8_t range);
+        void setFullScaleGyroRange(uint8_t range, float real);
         uint8_t getFullScaleAccelRange();
-        void setFullScaleAccelRange(uint8_t range);
+        void setFullScaleAccelRange(uint8_t range, float real);
 
         void autoCalibrateGyroOffset();
         bool getGyroOffsetEnabled();
@@ -640,6 +647,7 @@ class BMI160Class {
 
         uint8_t getDeviceID();
 
+        int isBitSet(uint8_t value, unsigned bit);
         uint8_t getRegister(uint8_t reg);
         void setRegister(uint8_t reg, uint8_t data);
 
@@ -653,8 +661,10 @@ class BMI160Class {
         void setInterruptLatch(uint8_t latch);
         void resetInterrupt();
 
-        bool gyroDataReady();
-        bool accelDataReady();
+        /* Use a bitmask to track which sensors are enabled */
+        unsigned sensors_enabled;
+        float accel_range;
+        float gyro_range;
 
     protected:
         virtual int serial_buffer_transfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt) = 0;

--- a/libraries/CurieIMU/src/CurieIMU.h
+++ b/libraries/CurieIMU/src/CurieIMU.h
@@ -94,8 +94,12 @@ class CurieIMUClass : public BMI160Class {
     friend void bmi160_pin1_isr(void);
 
     public:
+        bool begin(unsigned int sensors);
         bool begin(void);
         void end(void);
+
+        bool dataReady();
+        bool dataReady(unsigned int sensors);
 
         // supported values: 25, 50, 100, 200, 400, 800, 1600, 3200 (Hz)
         int getGyroRate();
@@ -207,10 +211,8 @@ class CurieIMUClass : public BMI160Class {
         void detachInterrupt(void);
 
     private:
+        bool configure_imu(unsigned int sensors);
         int serial_buffer_transfer(uint8_t *buf, unsigned tx_cnt, unsigned rx_cnt);
-
-        float accel_range;
-        float gyro_range;
 
         float getFreefallDetectionThreshold();
         void setFreefallDetectionThreshold(float threshold);


### PR DESCRIPTION
This method is a bit more flexible. There is a version with no
parameters, which will return true if all enabled sensors have new
data. There is one overload, that takes a single 'flags' parameter,
which returns true if all enabled *and* selected sensors have new data.
Sensors are selectable through pre-defined bit flags. For example;

    CurieIMU.dataReady() : this will return true if both the accel and gyro
    are enabled, and both have new data ready.

    CurieIMU.dataReady(ACCEL | GYRO) : this will return true if both the
    accel and gyro have new data ready (if one of the passed sensors is not
    enabled, it is ignored and the function will behave as if that sensor was not
    specified)

    CurieIMU.dataReady(GYRO) : this will return true if the gyro is
    enabled and has new data ready.

    CurieIMU.dataReady(ACCEL) : this will return true if the accel is
    enabled and has new data ready.

This also involved changing the 'begin' method to allow selective
enabling of sensors, e.g.

    CurieIMU.begin() : same as it always has, initializes IMU, enabling
    both accel and gyro

    CurieIMU.begin(ACCEL | GYRO) : initializes IMU, enabling both accel
    and gyro

    CurieIMU.begin(ACCEL) : initializes IMU, enabling accel only

    CurieIMU.begin(GYRO) : initializes IMU, enabling  gyro only