### PR TITLE
Jira 795, read() is blocking selectable, git 383

### DIFF
--- a/libraries/CurieBLE/src/BLECharacteristic.cpp
+++ b/libraries/CurieBLE/src/BLECharacteristic.cpp
@@ -367,14 +367,14 @@ bool BLECharacteristic::canUnsubscribe()
     return retVar;
 }
 
-bool BLECharacteristic::read()
+bool BLECharacteristic::read(bool blocked)
 {
     bool retVar = false;
     BLECharacteristicImp *characteristicImp = getImplementation();
     
     if (NULL != characteristicImp)
     {
-        retVar = characteristicImp->read();
+        retVar = characteristicImp->read(blocked);
     }
     return retVar;
 }

--- a/libraries/CurieBLE/src/BLECharacteristic.h
+++ b/libraries/CurieBLE/src/BLECharacteristic.h
@@ -320,8 +320,9 @@ public:
      * @return  bool    true - Success, false - Failed
      *
      * @note  Only for GATT client. Schedule read request to the GATT server
+     *        Arduino requests to have read, by default, be blocking.
      */
-    virtual bool read();
+    virtual bool read(bool blocked = true);
     
     /**
      * @brief   Write the charcteristic value

--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -145,7 +145,7 @@ uint8_t profile_read_rsp_process(bt_conn_t *conn,
                                  const void *data, 
                                  uint16_t length)
 {
-    if (NULL == data)
+    if (NULL == data && 0 != length)
     {
         return BT_GATT_ITER_STOP;
     }

--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
@@ -146,18 +146,18 @@ public:
     /**
      * @brief   Schedule the read request to read the characteristic in peripheral
      *
-     * @param[in]   none
+     * @param[in]   blocked    Flag the call is blocked or un-blocked
      *
      * @return  bool    Indicate the success or error
      *
-     * @note  Only for central device
+     * @note  Only for GATT client
+     *        Default it is block call as per Arduino request
      */
-    bool read();
+    bool read(bool blocked = true);
     
     /**
      * @brief   Schedule the write request to update the characteristic in peripheral
      *
-     * @param[in]   peripheral   The peripheral device that want to be updated
      * @param[in]   value       New value to set, as a byte array.  Data is stored in internal copy.
      * @param[in]   length      Length, in bytes, of valid data in the array to write.
      *                      Must not exceed maxLength set for this characteristic.
@@ -328,7 +328,7 @@ private:
     bt_gatt_subscribe_params_t _sub_params;
     bool        _subscribed;
     
-    bool _reading;
+    volatile bool _reading;
     static volatile bool _gattc_writing;
     bt_gatt_read_params_t _read_params; // GATT read parameter
     


### PR DESCRIPTION
Mods:
1. Add an input parameter to BLECharacteristic::read() for blocking
   call selection.
2. By default, read() is a blocking call.

File changes:
1. libraries/CurieBLE/src/BLECharacteristic.cpp:
   - Method read() added blocking selection.
2. libraries/CurieBLE/src/BLECharacteristic.h:
   - Prototype for read(), default is blocking.
3. libraries/CurieBLE/src/internal/BLECallbacks.cpp:
   - Added parameter checking in profile_read_rsp_process().
4. libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
   - The implementation of read() added waiting for resp if
     blocking is selected.
5. libraries/CurieBLE/src/internal/BLECharacteristicImp.h:
   - prototyping.