### PR TITLE
Jira 796, as Peripheral, initialization of local buffer incorrectly set the write flag, git 380

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
@@ -259,6 +259,7 @@ bool
 BLECharacteristicImp::setValue(const unsigned char value[], uint16_t length)
 {
     _setValue(value, length, 0);
+    _value_updated = true;
     if (BLEUtils::isLocalBLE(_ble_device) == true)
     {
         // GATT server
@@ -554,7 +555,6 @@ BLECharacteristicImp::_setValue(const uint8_t value[], uint16_t length, uint16_t
         }
     }
     
-    _value_updated = true;
     memcpy(_value + offset, value, length);
     _value_length = length;
 }


### PR DESCRIPTION
…onnect

1. Not set the flage when local device try to set the value.
2. Changed file
    libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp