### PR TITLE
Jira 804 BLE Characteristic initialization issue, git 366

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
@@ -171,6 +171,7 @@ BLECharacteristicImp::BLECharacteristicImp(BLECharacteristic& characteristic,
     if (NULL != characteristic._value)
     {
         memcpy(_value, characteristic._value, _value_size);
+        _value_length = _value_size;
     }
         
     // Update BLE device object


### PR DESCRIPTION
Issue:
-  Created Characteristic failed to reflect the initialized
   value.

Root cause:
-  During initialization, the length field was incorrectly
   skipped over.