### PR TITLE
EEPROM.cpp: Use double quotes for include file

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -16,7 +16,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <EEPROM.h>
+#include "EEPROM.h"
 
 EEPROMClass EEPROM;
 


### PR DESCRIPTION
<EEPROM.h> works in the Arduino IDE,  but it's not actually in a system
include location so it makes non-IDE (i.e. Klocwork) builds fail