### PR TITLE
Jira 842 UART improvement, PR 266, broke BLE interface.

### DIFF
--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -30,9 +30,9 @@ class RingBuffer
 {
 public:
 	uint8_t *_aucBuffer;
-	int _iHead ;
-	int _iTail ;
-	bool _buffer_overflow ;
+	volatile int _iHead ;
+	volatile int _iTail ;
+	volatile bool _buffer_overflow ;
 
 	RingBuffer( void ) ;
 	void store_char( uint8_t c ) ;

--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -168,7 +168,7 @@ int UARTClass::read( void )
 
 void UARTClass::flush( void )
 {
-  while (_tx_buffer->_iHead != _tx_buffer->_iTail); //wait for transmit data to be sent
+  while (_tx_buffer->_iHead != (_tx_buffer->_iTail)); //wait for transmit data to be sent
   // Wait for transmission to complete
   while(!uart_tx_complete(CONFIG_UART_CONSOLE_INDEX));
 }
@@ -183,8 +183,7 @@ size_t UARTClass::write( const uint8_t uc_data )
   {
     // If busy we buffer
     int l = (_tx_buffer->_iHead + 1) % UART_BUFFER_SIZE;
-    while (_tx_buffer->_iTail == l)
-      ; // Spin locks if we're about to overwrite the buffer. This continues once the data is sent
+    while (_tx_buffer->_iTail == l); // Spin locks if we're about to overwrite the buffer. This continues once the data is sent
 
     _tx_buffer->_aucBuffer[_tx_buffer->_iHead] = uc_data;
     _tx_buffer->_iHead = l;
@@ -201,21 +200,29 @@ size_t UARTClass::write( const uint8_t uc_data )
 
 void UARTClass::IrqHandler( void )
 {
-  uint8_t uc_data;
-  int ret;
-  ret = uart_poll_in(CONFIG_UART_CONSOLE_INDEX, &uc_data);
-  
-  while ( ret != -1 ) {
-    _rx_buffer->store_char(uc_data);
+  uart_irq_update(CONFIG_UART_CONSOLE_INDEX);
+  // if irq is Receiver Data Available
+  if(uart_irq_rx_ready(CONFIG_UART_CONSOLE_INDEX))
+  {
+    uint8_t uc_data;
+    int ret;
     ret = uart_poll_in(CONFIG_UART_CONSOLE_INDEX, &uc_data);
+    
+    while ( ret != -1 ) {
+      _rx_buffer->store_char(uc_data);
+      ret = uart_poll_in(CONFIG_UART_CONSOLE_INDEX, &uc_data);
+    }
   }
 
-  // Do we need to keep sending data?
-  if (!uart_irq_tx_ready(CONFIG_UART_CONSOLE_INDEX))
+  // if irq is Transmitter Holding Register
+  if(uart_irq_tx_ready(CONFIG_UART_CONSOLE_INDEX))
   {
-    if (_tx_buffer->_iTail != _tx_buffer->_iHead) {
-      uart_poll_out(CONFIG_UART_CONSOLE_INDEX, _tx_buffer->_aucBuffer[_tx_buffer->_iTail]);
-      _tx_buffer->_iTail = (unsigned int)(_tx_buffer->_iTail + 1) % UART_BUFFER_SIZE;
+    if(_tx_buffer->_iTail != _tx_buffer->_iHead)
+    {
+      int end = (_tx_buffer->_iTail < _tx_buffer->_iHead) ? _tx_buffer->_iHead : UART_BUFFER_SIZE;
+      int l = min(end - _tx_buffer->_iTail, UART_FIFO_SIZE);
+      l = uart_fifo_fill(CONFIG_UART_CONSOLE_INDEX, _tx_buffer->_aucBuffer+_tx_buffer->_iTail, l);
+      _tx_buffer->_iTail = (_tx_buffer->_iTail+l)%UART_BUFFER_SIZE;
     }
     else
     {


### PR DESCRIPTION
Root causes:

  1. The uart_fifo_fill doesn't check the FIFO's length
     and failed to send out all data.
  2. Check the FIFO status register before write data
     in FIFO.
  3. Ring buffer pointer variables are not volatile and
     polling mechanism failed to examine the actual
     pointer value being update by foreground task.

File changes:

  1. RingBuffer.h:  Make pointer as volatile.
  2. UARTClass.cpp:  Added checking of FIFO size for
     data Tx.
  3. ns16550.c:  Added routines to h/w status register
     checking.