### PR TITLE
Jira 832 Sketch cannot exercise BLE broadcast, git 420

### DIFF
--- a/libraries/CurieBLE/src/BLECharacteristic.cpp
+++ b/libraries/CurieBLE/src/BLECharacteristic.cpp
@@ -294,8 +294,8 @@ bool BLECharacteristic::broadcast()
     if (BLEDeviceManager::instance()->advertising())
     {
         BLEDeviceManager::instance()->stopAdvertising();
-        BLEDeviceManager::instance()->startAdvertising();
     }
+    BLEDeviceManager::instance()->startAdvertising();
     return _broadcast;
 }
 


### PR DESCRIPTION
Root Cause:
  Need to restart advertising after setting the broadcast option
in Characteristic.  Otherwise, broadcasting would not take
effect.

Code mods:

1. libraries/CurieBLE/src/BLECharacteristic.cpp:
   - At the processing of the Boardcast option in the
     characteristic, stop and restart advertising if advertising
     has already started.