### PR TITLE
flash.ld: fix mis-aligned .data section

### DIFF
--- a/variants/arduino_101/linker_scripts/flash.ld
+++ b/variants/arduino_101/linker_scripts/flash.ld
@@ -113,6 +113,7 @@ SECTIONS
 	__data_ram_start = .;
 	*(.data)
 	*(".data.*")
+	. = ALIGN(4);
 	} > SRAM
 
     __data_ram_end = .;


### PR DESCRIPTION
The end of the .data section in flash must be explicitly word-aligned, otherwise
corruption can occur in a .data section that happens to contain non-word aligned
data.

Additionally, the symbols __data_ram_end and __data_rom_start should
really be inside a section (instead of just floating around).
It is functionally equivalent, however it makes the linker script much easier
to understand!

EDIT: @bigdinotech I was wrong, probably shouldn't have moved the symbols inside input sections.
https://sourceware.org/binutils/docs/ld/Location-Counter.html

"... Note: . actually refers to the byte offset from the start of the current containing object. Normally this is the SECTIONS statement, whose start address is 0, hence . can be used as an absolute address. If . is used inside a section description however, it refers to the byte offset from the start of that section, not an absolute address..."

Just adding the extra ALIGN is all that was needed.