### PR TITLE
Jira 857, 858, BLEPeripherial connect issues

### DIFF
--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -21,7 +21,7 @@
 
 #include "BLEPeripheral.h"
 
-static BLEPeripheralEventHandler m_eventHandlers[BLEDeviceLastEvent];
+static BLEPeripheralEventHandler m_eventHandlers[BLEDeviceLastEvent] = {NULL, NULL, NULL, NULL};
 
 void bleBackCompatiblePeripheralConnectHandler(BLEDevice central) 
 {
@@ -154,7 +154,6 @@ void BLEPeripheral::init()
     if (!_initCalled)
     {
         BLE.begin();
-        memset(m_eventHandlers, 0, sizeof(m_eventHandlers));
         _initCalled = true;
     }
 }

--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -146,7 +146,8 @@ BLECentral BLEPeripheral::central(void)
 
 bool BLEPeripheral::connected(void)
 {
-    return BLE.connected();
+    BLEDevice centralBle = BLE.central();
+    return centralBle.connected();
 }
 
 void BLEPeripheral::init()


### PR DESCRIPTION
Jira 857. BLEPeripheral::connect() return false, git 444.
Jira 858. Cannot trigger BLEConnected and BLEDisconnected events, git 445.

Both related connection issues are address in this PR.