### PR TITLE
Jira 793 Support Characteristic UUID that is not subset of Service, g…

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -172,6 +172,23 @@ uint8_t profile_service_read_rsp_process(bt_conn_t *conn,
     return ret;
 }
 
+uint8_t profile_characteristic_read_rsp_process(bt_conn_t *conn, 
+                                                 int err,
+                                                 bt_gatt_read_params_t *params,
+                                                 const void *data, 
+                                                 uint16_t length)
+{
+    BLEDevice bleDevice(bt_conn_get_dst(conn));
+    BLEServiceImp* service_imp = BLEProfileManager::instance()->getServiceBySubHandle(bleDevice, params->single.handle);
+    
+    uint8_t ret = service_imp->characteristicReadRspProc(conn, 
+                                                         err,
+                                                         params,
+                                                         data,
+                                                         length);
+    pr_debug(LOG_MODULE_BLE, "%s-%d:ret-%d", __FUNCTION__, __LINE__, ret);
+    return ret;
+}
 
 
 void bleConnectEventHandler(bt_conn_t *conn, 

--- a/libraries/CurieBLE/src/internal/BLECallbacks.h
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.h
@@ -76,6 +76,11 @@ uint8_t profile_service_read_rsp_process(bt_conn_t *conn,
 
 void ble_on_write_no_rsp_complete(struct bt_conn *conn, uint8_t err,
                                          const void *data);
+uint8_t profile_characteristic_read_rsp_process(bt_conn_t *conn, 
+                                                 int err,
+                                                 bt_gatt_read_params_t *params,
+                                                 const void *data, 
+                                                 uint16_t length);
 
 #endif
 

--- a/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
@@ -507,6 +507,40 @@ BLEServiceImp* BLEProfileManager::service(const BLEDevice &bledevice, int index)
     return serviceImp;
 }
 
+BLEServiceImp* BLEProfileManager::getServiceBySubHandle(const BLEDevice &bledevice, uint16_t handle) const
+{
+    BLEServiceImp* serviceImp = NULL;
+    uint16_t start_handle;
+    uint16_t end_handle;
+
+    const BLEServiceLinkNodeHeader* serviceHeader = getServiceHeader(bledevice);
+    if (NULL == serviceHeader)
+    {
+        // Doesn't find the service
+        return NULL;
+    }
+    BLEServiceNodePtr node = serviceHeader->next;
+    
+    while (node != NULL)
+    {
+        serviceImp = node->value;
+        start_handle = serviceImp->startHandle();
+        end_handle = serviceImp->endHandle();
+        if (handle >= start_handle && handle <= end_handle)
+        {
+            break;
+        }
+        node = node->next;
+    }
+    
+    if (NULL == node)
+    {
+        serviceImp = NULL;
+    }
+
+    return serviceImp;
+}
+
 void BLEProfileManager::handleConnectedEvent(const bt_addr_le_t* deviceAddr)
 {
     int index = getUnusedIndex();

--- a/libraries/CurieBLE/src/internal/BLEProfileManager.h
+++ b/libraries/CurieBLE/src/internal/BLEProfileManager.h
@@ -98,6 +98,7 @@ public:
     BLEServiceImp* service(const BLEDevice &bledevice, const char * uuid) const;
     BLEServiceImp* service(const BLEDevice &bledevice, int index) const;
     BLEServiceImp* service(const BLEDevice &bledevice, const bt_uuid_t* uuid) const;
+    BLEServiceImp* getServiceBySubHandle(const BLEDevice &bledevice, uint16_t handle) const;
     int serviceCount(const BLEDevice &bledevice) const;
     int characteristicCount(const BLEDevice &bledevice) const;
     

--- a/libraries/CurieBLE/src/internal/BLEServiceImp.h
+++ b/libraries/CurieBLE/src/internal/BLEServiceImp.h
@@ -71,6 +71,12 @@ public:
     uint8_t discoverResponseProc(bt_conn_t *conn,
                                  const bt_gatt_attr_t *attr,
                                  bt_gatt_discover_params_t *params);
+    
+    uint8_t characteristicReadRspProc(bt_conn_t *conn, 
+                                      int err,
+                                      bt_gatt_read_params_t *params,
+                                      const void *data, 
+                                      uint16_t length);
     bool discovering();
     
     static bt_uuid_t *getPrimayUuid(void);
@@ -81,6 +87,13 @@ protected:
     
     
     int updateProfile(bt_gatt_attr_t *attr_start, int& index);
+    
+private:
+    void discoverNextCharacteristic(BLEDevice &bledevice);
+    bool readCharacteristic(const BLEDevice &bledevice, uint16_t handle);
+    bool discoverAttributes(BLEDevice* device, 
+                            uint16_t start_handle, 
+                            uint16_t end_handle);
 private:
     typedef LinkNode<BLECharacteristicImp *>  BLECharacteristicLinkNodeHeader;
     typedef LinkNode<BLECharacteristicImp *>* BLECharacteristicNodePtr;
@@ -88,6 +101,9 @@ private:
     
     uint16_t _start_handle;
     uint16_t _end_handle;
+    
+    static bt_gatt_read_params_t _read_params;
+    bool _reading;
     
     void releaseCharacteristic();
     BLECharacteristicImp *_cur_discover_chrc;


### PR DESCRIPTION
…it 384

Root cause:
  - Nordic stack does not return long UUID for Characteristic
    discovery.  It is expecting Characteristic UUID is a
    subset of the Service UUID (eg. a sequential increament of
    the Service UUID).
  - In order for the Central mode (to behave like Apple) to
    discover long Characteristic UUID, the process is now done
    in two steps (similar to the Service discovery).  First,
    initiate a read of the Characteristic and then discover the
    long UUID upon successful read.

Code Mods:

1. BLECallbacks.cpp:
   - Added a call back to handle the read Characteristic
     completion event.
2. BLECallbacks.h:
   - Prototyping.
3. BLEProfileManager.cpp:
   - Added getServiceBySubHandle() to enable the call back to
     locate the Service of a discovered Characteristic.
4. BLEProfileManager.h:
   - Prototyping.
5. BLEServiceImp.cpp:
   - This is where the two steps Characteristic discovery is
     implemented.  At discoverAttributes(), reading of
     Characteristic is first initiated.  When the stack
     completes the operation, extract the UUID thereafter.
   - To support this two steps process, additional functions,
     discoverNextCharacteristic and readCharacteristic, are
     added.
6. BLEServiceImp.h:
   - Prototyping.

    - Change the discover process.
    - Add read operation after discover returned invalid UUID.