### PR TITLE
CDC-ACM CODK-M firmware compatibility changes

### DIFF
--- a/cores/arduino/CDCSerialClass.cpp
+++ b/cores/arduino/CDCSerialClass.cpp
@@ -30,6 +30,7 @@
 #include "wiring_digital.h"
 #include "variant.h"
 
+#define CDCACM_FIXED_DELAY     64
 
 extern void CDCSerial_Handler(void);
 extern void serialEventRun1(void) __attribute__((weak));
@@ -132,7 +133,7 @@ void CDCSerialClass::flush( void )
 
 size_t CDCSerialClass::write( const uint8_t uc_data )
 {
-    uint32_t retries = 1;
+    uint32_t retries = 2;
 
     if (!_shared_data->device_open || !_shared_data->host_open)
         return(0);
@@ -147,9 +148,8 @@ size_t CDCSerialClass::write( const uint8_t uc_data )
             _tx_buffer->data[_tx_buffer->head] = uc_data;
             _tx_buffer->head = i;
 
-	    // Mimick the throughput of a typical UART by throttling the data
-	    // flow according to the configured baud rate
-	    delayMicroseconds(_writeDelayUsec);
+	    // Just use a fixed delay to make it compatible with the CODK-M based firmware
+	    delayMicroseconds(CDCACM_FIXED_DELAY);
             break;
         }
     } while (retries--);

--- a/tatus
+++ b/tatus
@@ -1,0 +1,4812 @@
+[33mcommit 178bb5f58570f9e71b7423940c11e4d6d97e8f1a[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Feb 22 14:08:30 2017 -0800
+
+    CDC-ACM CODK-M firmware compatibility changes
+    
+    -compatibility changes for CDC-ACM usb serial to work with upcoming
+    CODK-M based firmware
+    -use a fixed delay between writes instead of trying to mimick UART
+    throttling
+
+[33mcommit ee08a03b21d5c141020b328974c2392a8484dfa9[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Fri Jan 27 16:28:38 2017 -0800
+
+    Use single dataReady() method, instead of accelDataReady/gyroDataReady
+    
+    This method is a bit more flexible. There is a version with no
+    parameters, which will return true if all enabled sensors have new
+    data. There is one overload, that takes a single 'flags' parameter,
+    which returns true if all enabled *and* selected sensors have new data.
+    Sensors are selectable through bit flags. For example;
+    
+        CurieIMU.dataReady() : this will return true if both the accel and gyro
+        are enabled, and both have new data ready.
+    
+        CurieIMU.dataReady(ACCEL | GYRO) : this will return true if both the
+        accel and gyro are enabled, and both have new data ready.
+    
+        CurieIMU.dataReady(GYRO) : this will return true if the gyro is
+        enabled and has new data ready.
+    
+        CurieIMU.dataReady(ACCEL) : this will return true if the accel is
+        enabled and has new data ready.
+    
+    This also involved changing the 'begin' method to allow selective
+    enabling of sensors, e.g.
+    
+        CurieIMU.begin() : same as it always has, initializes IMU, enabling
+        both accel and gyro
+    
+        CurieIMU.begin(ACCEL | GYRO) : initializes IMU, enabling both accel
+        and gyro
+    
+        CurieIMU.begin(ACCEL) : initializes IMU, enabling accel only
+
+[33mcommit fb578000afad9bc5cdf74358e8c3acbc7a04f9e8[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Wed Feb 15 22:28:08 2017 -0800
+
+    Jira 792, Support addition UUID types, git PR 386.
+    
+    Features added:
+    
+    1.  Add the support for two addition UUID types,
+        UUID16_SOME and UUID128_SOME.  These types,
+        practically, behaves the same as their related
+        ALL types.  Sandeep found that the Apple devices
+        made use of these additional types and requested
+        for their support.
+    
+    File mods:
+    
+    1.  BLEDeviceManager.cpp:
+        - Add UUID16_SOME and  UUID128_SOME at places
+          checking for UUID types.
+
+[33mcommit f61091473e5888337098a103daccf321e3fe328c[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Wed Feb 8 10:59:09 2017 +0800
+
+    Jira 804 BLE Characteristic initialization issue, git 366
+    
+    Issue:
+    -  Created Characteristic failed to reflect the initialized
+       value.
+    
+    Root cause:
+    -  During initialization, the length field was incorrectly
+       skipped over.
+
+[33mcommit ff32c97b547b42e8afa3e423c7ad9ddf4057b4dd[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Tue Dec 20 18:21:23 2016 +0800
+
+    BLE Peripheral cannot discover Central attributes
+    
+    1. Add test sketches discoveratperipheral.ino and profileatcentral.ino
+    2. Modify BLEDeviceManager.cpp to add central to profile buffer in peripheral
+        role.
+
+[33mcommit d6c68f26914bf9508e8b76081d383a5cd432c7b6[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Feb 14 12:40:25 2017 -0800
+
+    flash.ld: fix mis-aligned .data section
+    
+    The end of the .data section in flash must be explicitly word-aligned,
+    otherwise corruption can occur in a .data section that happens to contain
+    non-word aligned data.
+
+[33mcommit 0285190f5d94dd2228a33ec5ef91d0e3cecfed56[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Thu Feb 9 10:18:37 2017 -0800
+
+    EEPROM.cpp: Use double quotes for include file
+    
+    <EEPROM.h> works in the Arduino IDE,  but it's not actually in a system
+    include location so it makes non-IDE (i.e. Klocwork) builds fail
+
+[33mcommit 547ecd723e39da4044cb636d6bdbb8956cb2f2f2[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Fri Jan 13 09:04:29 2017 +0800
+
+    Sketch crash using both Firmata and BLE library, gitHub issue #377
+    
+    1. The BLEStream object adds profile when boot but the HW doesn't be
+        initialized and makes APP crash.
+    2. Change the BLE initial process not depend on HW. Buffer the
+        attributes if HW not initialized.
+    3. Changed files
+        libraries/CurieBLE/src/BLEDevice.h - expose constructor
+        libraries/CurieBLE/src/BLEPeripheral.cpp - not call HW init function
+        libraries/CurieBLE/src/internal/BLEDeviceManager.cpp - change init order
+        libraries/CurieBLE/src/internal/BLEProfileManager.cpp - change constructor
+
+[33mcommit fe14b8bd2600544330e95ccf22f7f91c114467c0[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Mon Feb 6 14:13:37 2017 +0800
+
+    Fix #380 characteristic written returns incorrect value after first connect
+    
+    1. Not set the flage when local device try to set the value.
+    2. Changed file
+        libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp
+
+[33mcommit 0eac6a00a766e424b87aecbbb734eb76bcb71694[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Fri Jan 13 22:07:08 2017 +0800
+
+    Jira 794 Inconsistent writeInt() result with different Peripherals, git 385
+    
+    Root cause:
+    -  As a Central, the write() operation can produce two different
+       commands to a Peripheral depending on the Characteristic.
+    -  One command is a simple write without aknowledgement from
+       Peripheral and the other requires a complete handshake for
+       each write operation.
+    -  Root cause of the issue was that the function,
+       BLECharacteristicImp::write(), did not check the
+       characteristic property to determine if the caller requires
+       a response.  It just treats all calls do not require a
+       response.
+    
+    Feature added:
+    -  For write with respond from Peripheral, it is now a
+       blocking call (it also satisfied Arduino's request).
+    
+    Modifications:
+    1. libraries/CurieBLE/src/internal/BLECallbacks.cpp:
+       - ble_on_write_no_rsp_complete:  CB to process Peripheral
+         Response to complete a write operation.
+    2. libraries/CurieBLE/src/internal/BLECallbacks.h:
+       - Function definition added.
+    3. libraries/CurieBLE/src/internal/BLECharacteristicImp.cpp:
+       - In function write(), check the characteristic property to
+         determine whether the call requires a response.
+       - Added a flag to signal the waiting on Peripheral
+         Response for a write operation.
+       - Write with response is now a blocking call.
+    4. BLECharacteristicImp.h:
+       - Prototyping.
+
+[33mcommit 40b0c43967187137c9bde6bf88f57732a8a30aa4[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Mon Jan 9 10:50:13 2017 +0800
+
+    Jira 797, Central can scan with MAC address, git 376
+    
+    New feature:
+    -  Add the capability for a Central to scan for a
+       Peripheral using its MAC address.
+    
+    Code Modifications:
+    -  Added the API for MAC address scanning.
+    -  For Device Manager, added provision for holding the
+       MAC address of a Peripheral.
+    -  For scan discovery handler, added the checking
+       for MAC address comparison, if MAC address scanning
+       is requested.
+    
+    File changes:
+    
+    1. libraries/CurieBLE/src/BLEDevice.cpp:
+       - Added API for MAC address scanning.
+    2. libraries/CurieBLE/src/BLEDevice.h:
+       - API definition.
+    3. libraries/CurieBLE/src/internal/BLEDeviceManager.cpp:
+       - Added provision for storing the MAC address.
+       - Added MAC address comparison in the scan discovery
+         handle if MAC address scanning is selected.
+    4. libraries/CurieBLE/src/internal/BLEDeviceManager.h:
+       - Prototyping.
+
+[33mcommit 78c3d0ad0a5475f7809d31dfd1c2d75cbcf4a58c[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Thu Feb 2 13:49:50 2017 -0800
+
+    EEPROM library: move function definitions into separate .cpp files
+
+[33mcommit 001cab44592510cf9ea799d7a6f34d237d5b149c[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Feb 1 11:36:59 2017 -0800
+
+    freeMemory.ino: add introductory comment
+
+[33mcommit b60860237540cde903b81615c3324f47f03cd756[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Jan 10 15:18:27 2017 -0800
+
+    Add new library MemoryFree
+    
+    This is the MemoryFree libary from
+    http://playground.arduino.cc/code/AvailableMemory, rewritten specifically
+    for Arduino 101 and tinyTILE. It provides some functions for querying
+    available stack & heap space.
+
+[33mcommit 29daefb64ae643a0cb2bcb15b586e90a206bf7e8[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 10 10:24:15 2017 -0800
+
+    add support for Power Management library
+
+[33mcommit cd3215bd5929dd83004cdf3b94e32726ff2eba2e[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 10 10:17:13 2017 -0800
+
+    expose all AON-GPIOs
+    
+    -expose AON-GPIOs since they are available on the TinyTILE
+
+[33mcommit 90e8bc65828a7e65f5a59d9a64c3db7df185e0a3[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 10 09:55:59 2017 -0800
+
+    shared memory structure changes for CODK-M
+    
+    -added struct for ipm using shared memory
+    -added cdc-acm buffer space on shared memory which is used by the new firmware
+
+[33mcommit 7c97231c087929a90ae880486b3c0ce539a9b326[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Jan 10 10:31:56 2017 -0800
+
+    CurieIMU.cpp: initialize saved accel/gyro ranges in begin()
+    
+    This ensures that "read[Accelerometer/Gyro]Scaled()" will work as
+    expected even if a range has not been explicitly set using the API
+
+[33mcommit 17d2e2fb22ba0cd239c46973cca0006704534195[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Mon Jan 9 10:55:34 2017 -0800
+
+    Rebuild libarc32drv_arduino101.a
+
+[33mcommit 5d91dc66fe0f49ab5cb9d5dc7459a9abba5ea7de[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Thu Dec 29 17:57:17 2016 -0800
+
+    libarc32_arduino101/Makefile: Add 'strip' target
+    
+    The file libarc32drv_arduino101.a is built with debugging symbols by
+    default, however the version we ship needs to be stripped. The new
+    "strip" target makes it easy for us to strip when committing, and
+    the default target still behaves the same way, so the library can be
+    re-compiled for debugging purposes
+
+[33mcommit 4ae5af7f8a63dfaa9d44b35c0c820d93a4a6980e[m
+Author: Noel Paz <noel.f.paz@intel.com>
+Date:   Thu Dec 22 13:24:24 2016 -0800
+
+    Corrected the MIDIBLE example so it advertises correctly
+
+[33mcommit 621949108d0c3def12722b626b57176d10425863[m
+Author: noelpaz <noelpaz@users.noreply.github.com>
+Date:   Wed Dec 21 17:10:09 2016 -0800
+
+    Modified SensorTag example and added examples derived from 1.0.7
+
+[33mcommit 2391f48210995aa34fc20e62745811aeaaa0bd7d[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Wed Dec 21 00:48:55 2016 -0800
+
+    Moving balloc static memory buffer to DCCM memory
+    
+    balloc() is used by interrupt context code for memory allocation. The memory space is statically allocated at
+    initialization.  In order not to take up SRAM memory, this buffer is moved to the DCCM memory space.
+
+[33mcommit 34d0e50135f9e0baff349fe116f92d049e9f97c9[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Tue Dec 20 13:11:21 2016 -0800
+
+    I2S example sketches failed compliation, Jira 786.
+    
+    The latest BLE library consumes more heap space that causes these sketches ran out of heap space for their temporary
+    buffers.  For now, the size of the tempporary is reduced.  For the near future, there are 3 improvements to address
+    this issue.  The BLE library will be making use of the DCCM memory instead of heap.  The I2S library buffering space
+    is going to the DCCM memory too.  The heap space will be increased to maximize the usage of the entire SRAM sapce.
+
+[33mcommit 4c89a183f8e509c3f7c08a589a291ebb91ee171e[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Mon Dec 19 14:59:55 2016 +0800
+
+    Add test sketches
+
+[33mcommit ade23f0c2c064b733a1c3d264eb29e1a608f8745[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Mon Oct 17 16:11:18 2016 +0800
+
+    Arduino BLE new library
+    
+    1. Add new library
+    
+    2. Add BLEPeripheral library back compatible features
+    
+    3. Fix IMU build issue
+    
+    4. Fix the memset crash issue
+      i.  The FIRQ doesn't save the LP_COUNTER register.
+      ii. Update the code to save LP related register
+    
+    5. Fix the central crash issue when peripheral disconnect
+    
+    6. Revert the UART changes
+       -This change will break the BLE's communication
+    
+    7. Implement the balloc to replace old one
+       -Create memory pool
+       -Port V3's balloc
+       -Fix the local name display unexpected chars
+    
+    8. Fix ScanCallback, LED related issue
+       -The Serial.print called in interrupt and interrupt block the Serial interrupt.
+       -The resource not released when call disconnect API.
+    
+    9. Fix the discover blocked when connect/disconnect the link successively
+    
+    Block the disconnect if not receive the disconnect event
+    
+    10. Return error when discover attributes if error happened
+    
+    11. Update the back compatible comments
+    
+    12. Fix the discover attribute failed issue
+        -Add the -fcheck-new build option
+        -Increase the IRQ stack size
+    
+    13. Add discoverAttributesByService API
+        - The sensorTag has many services and RAM is not enough for discover all services
+        -This crash caused by bt_uuid_16 and bt_uuid_128 has different space and makes an address exception
+    
+    14. Add keywords and fix read issue
+    
+    15. Update the CurieBLE and delete BLE
+
+[33mcommit 431c7812e71c904b0e8212a0234d520ffbbe2b0d[m
+Author: Dino Tinitigan <dino.tinitigan@intel.com>
+Date:   Tue Dec 13 16:16:17 2016 -0800
+
+    check mux mode when using digitalWrite (#335)
+    
+    -check and make sure that the pin is in GPIO_MUX_MODE when doing a
+    digitalWrite()
+    -this has a slight performance impact of digitalWrite
+    -it also comsumes an extra byte in SRAM per pin
+    -it does however give us the ability to track the muxing state of each
+    pin
+
+[33mcommit 16227f53f2591eaa47e551b8000878855294eb35[m
+Author: Dino Tinitigan <dino.tinitigan@intel.com>
+Date:   Tue Dec 13 16:15:51 2016 -0800
+
+    Ensure RTC clock scaling is set to 1Hz (#350)
+    
+    -needed to make sure that the RTC scaling is consitent with the factory
+    firmware and CODK-M based firmware
+
+[33mcommit 0d321db5cc619dc9a4451a6710dabd38fee492bf[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Nov 29 11:32:50 2016 -0800
+
+    CurieIMU.cpp: Don't lock interrupts for SPI transfers
+    
+    This is unnecessary- nothing else is contending for access to this
+    particular SPI controller
+
+[33mcommit e870ba255646afa47debfc0b1cb493cc055520dd[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Nov 29 13:27:38 2016 -0800
+
+    Ensure RTC clock scaling is set to 1Hz
+    
+    -needed to make sure that the RTC scaling is consitent with the factory
+    firmware and CODK-M based firmware
+
+[33mcommit de208be5c42a305624468d9a1a5208f60d0b5bdb[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Nov 29 10:35:10 2016 -0800
+
+    README.md: add steps for updating intel-arduino-tools
+
+[33mcommit 2bb7d4b58e4152fde9b87153f71618475f54c42a[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Fri Oct 21 16:20:37 2016 -0700
+
+    README.md: remove Serial1 debug information
+
+[33mcommit 205c1e40852f356a4819a16260086e8f3c719592[m
+Author: Adrien Descamps <adrien.descamps@gmail.com>
+Date:   Thu Aug 11 23:13:02 2016 +0200
+
+    Enable interrupt mode of UART tx
+    
+    Previous version of write will never use the interrupt mode
+    transmission, because it fails to check if holding register is
+    empty. This commit fix that, and several bugs related to
+    interrupt mode serial transmission.
+    When possible, it uses the tx FIFO, in order to reduce
+    the number of interrupts called and the overhead.
+
+[33mcommit 5279509cc2f6d161e1607245f15024e5d578c10e[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Mon Nov 14 10:12:39 2016 -0800
+
+    CurieTime.cpp: check gmtime() return pointer for NULL-ness
+
+[33mcommit 249fb3b7b6a7ebf85a202688c960de9f256a8018[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Mon Nov 14 16:20:09 2016 -0800
+
+    README.md: add link to ICS for product support
+
+[33mcommit c353f4caa7e5d9a4287410f2826f8e75683ab13c[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Oct 27 15:57:39 2016 -0700
+
+    Use our own version of copy.exe so that we can copy without cmd.exe
+
+[33mcommit 6ee828b737b4bd08dda78b0769bb9043c64d2c4c[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Oct 20 15:53:53 2016 -0700
+
+    Move SoftwareSerial buffers into DCCM area
+
+[33mcommit 41f98f9c459a0ed7175b34c9c334c03c352c0706[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Oct 20 15:14:47 2016 -0700
+
+    Allocate RingBuffer buffer into DCCM area
+    
+    -this buffer is used by the uart. Moving it into the DCCM area would
+    save us 128 bytes of SRAM
+
+[33mcommit 8619f2b3e088c28c389550a19ecf2e2e3029543e[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Oct 20 11:35:08 2016 -0700
+
+    Move buffers for Wire library to DCCM area
+
+[33mcommit 4e2232e3e55ab68da0e125f59da2817f45b7e06d[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Oct 19 15:26:19 2016 -0700
+
+    Expose dccm area
+    
+    -expose dccm area giving the user an extra 8k of memory
+    -simple implementation of a malloc like function for dccm memory area
+
+[33mcommit 1c8de0d7cc0ecf93abeb539bd97b0fee2b09eb97[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Oct 11 10:11:29 2016 -0700
+
+    Add functions to check if new IMU data is available
+    
+    accelDataReady() and gyroDataReady() read the drdy_acc and drdy_gyr
+    bits, respectively, of the BMI160's sensor status register. This removes
+    the burden of syncronising sensor reads from the user.
+    
+    (adapted from descampsa/corelibs-arduino101@773a800)
+
+[33mcommit 3d3c1f92c2c15724725f71542bc564754ba5d6e3[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Oct 12 15:42:50 2016 -0700
+
+    I2SDMA: Do not modify g_APinDescription
+    
+    The g_APinDesctiption is now 'const', so cannot be modified.
+
+[33mcommit d6b2ecaa47bd543dbb35a33b36dfa2fb9037de86[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Sep 28 12:54:37 2016 -0700
+
+    pwm improvements
+    
+    -add capability to change pwm signal frequency with analogWriteFrequency
+    -improve pwm signal frequency accuracy
+
+[33mcommit 27a68decb8e450f52b7c4c9dc254a1b0cb045b17[m
+Author: Biagio Montaruli <biagio.hkr@gmail.com>
+Date:   Wed Sep 7 13:15:41 2016 +0200
+
+    Update sketches that use serial communication of different libraries
+    
+    Improve sketches of CurieTime, CurieTimerOne, CurieSoftwareSerial, SPI and
+    SerialFlash libraries that use Serial communication.
+    Since Arduino/Genuino 101 uses USB native port, wait for the Serial port
+    to open to not lose serial data already sent to the Serial monitor.
+    
+    Signed-off-by: Biagio Montaruli <biagio.hkr@gmail.com>
+
+[33mcommit 39ef9ef12c50366c4b77f494ae53361bbaf2118c[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Fri Oct 7 11:07:44 2016 -0700
+
+    Don't save unstripped elf for debugging (#314)
+    
+    The current save mechanism breaks when a user has deleted system32 from PATH environment variable. Comment out the copying so that it won't break for such users, but do not delete so that advanced users can use the unstripped elfs to debug.
+
+[33mcommit c396a3ad4f0ffb9163b0a2b270aa4584848764f3[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Tue Oct 4 16:59:36 2016 -0700
+
+    Shrink oversized objects in SRAM
+    
+    824 bytes is gained for use by sketches. Two new defines are added;
+    CDCACM_BUFFER_SIZE and UART_BUFFER_SIZE. The CDC-ACM Serial class and
+    the UART driver had been using the same #define for buffer size--
+    SERIAL_BUFFER_SIZE-- and separating them means that the CDC-ACM buffer
+    can stay the same size, while the UART buffer is shrunk.
+
+[33mcommit 1a5e3f7b2d65cf2b81417f85bd24ca455bdaa1fc[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Thu Sep 29 15:17:07 2016 -0700
+
+    Make g_APinDescription const
+    
+    This has the effect of moving g_APinDescription out of .data (SRAM),
+    and into .rodata (flash).
+    
+    Pros:
+    sketches now have an additional 1160 bytes of SRAM available
+    
+    Cons:
+    state of pins is no longer tracked; e.g. when calling digitalWrite,
+    the full configuration is done each time. See changes in wiring_digital.c
+    and wiring_analog.c for details. There is inevitably a performance impact
+    for digitalRead/Write & analogRead/Write, though it is unlikely to be a
+    noticable one.
+
+[33mcommit 2e56b81a264c8760f095a12f650381b8ea8de831[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Sep 28 12:02:32 2016 -0700
+
+    stdlib_noniso.cpp: Handle rounding corner case for dtostrf
+    
+    Rounding must be done before separating the integral and decimal portions.
+
+[33mcommit f2a001f4fa557c4374493242c67ecee617a59866[m
+Merge: 77d9086 d2b7d1d
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Sep 22 11:57:28 2016 -0700
+
+    Add BLE Central feature
+
+[33mcommit d2b7d1d732ca2ace5eb3f3da2e5cf3371e104f54[m
+Author: unknown <jysholar@jysholar-MOBL.amr.corp.intel.com>
+Date:   Mon Sep 12 10:33:51 2016 -0600
+
+    JIRA-685, Peripheral sketches shall state associated Central sketch.
+
+[33mcommit 9581cf18a0a904e096f1dcab30624871c22714c4[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Mon Aug 29 14:01:05 2016 -0700
+
+    Update expected BLE version for V3
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 0304de781d54d0158c070d2d9cc750ab295c0712[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Fri Sep 9 10:55:17 2016 -0700
+
+    Rebuilt libarc32drv
+
+[33mcommit 84fc3dbbfb900d0d5cf5b8b2a9c7e734accb5771[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Fri Sep 9 08:28:50 2016 +0800
+
+    Create BLE Example sketches
+    
+    1. Fix Jira 664 demonstrates changing the ADV data
+    2. Fix Jira 671 Support update connection interval in central/peripheral
+
+[33mcommit e7238f02c945faf6a05eca38ae590d520ec2af62[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Fri Sep 9 08:25:31 2016 +0800
+
+    Jira Tickets and Bug fix
+    
+    1. Jira 541 Peripheral Start fails on X Number of Attributes
+        -Change the interface and add return value
+    
+    2. Fix BLE Peripheral is not advertising
+        -Add a delay after register the profile.
+    
+    3. Modify some comments based on code review
+    
+    4. Jira 544 BLE peripheral disconnect and end functions
+        -The state not aligned and make disconnect failed. Update when connect and disconnect event received
+    
+    5. Delete the duplicated code that base class has implemented
+    
+    6. Fix Jira 665 BLECentral Preview -- compile issue when instantiating BLE descriptor
+        -Fix the build error.
+        Note:
+          i  . The current code only support one descriptor on characteristic.
+          ii . The central discover logic need more twist.
+          iii. Now is so long and can't process CCCD and another characteristic.
+          iv . The library will support one other descriptor except CCCD.
+    
+    7. Improve the discover logic and support another descriptor
+        i.  Improve the discover logic
+        ii. Support another the descriptor and CCCD at same time.
+    
+    8. Modify the comments and delete the unused API
+    
+    9. Fix Jira 670 A compile error occurs with two BLE methods with the same name
+        i.  Add method uuid_cstr in BLEAttribute class.
+        ii. Remove the duplicate file.
+    
+    10. Fix Jira 672 BLE documentation in code needs to specify units
+        i.   Change the scan and connection interval's unit to ms.
+        ii.  Unify the advertising interval unit as millisecond
+        iii. Delete some unused code.
+    
+    11. Fix Jria 671 Support update connection interval in central/peripheral
+         i. Central can update the connection interval.
+         ii. Unify the interval unit to ms at user API.
+    
+    12. Adjust the example comments and functions
+         i.  Fix Jira 675 - BLE callbacks should use passed arguments instead of global variables
+         ii. Adjust the code struture to align with Arduino's requirement
+    
+    13. Fix Jira 680 LED and LED Central sketches need some work
+         -Add a delay to make sure profile register process success.
+         -The UART send too fast may makes the profile registration failed.
+    
+    14. Fix Jira 673 BLE Api should pass arguments that are typedef
+    
+    15. Fix Jira 671 Support update connection interval in central/peripheral
+         i. Add peripheral update the connection interval feature.
+         ii. Update the library.
+    
+    16. Fix Jira  687 Edit the keyword.txt of CurieBLE to reflect Library changes
+    
+    17. Make example function ready. But need to resolve Jira 675
+    
+    18. Fix Jira 676 Review Edit Update BLE User Manual with China Flex
+    
+    19. Fix Jira 685 BLE Peripheral sketches shall state which associated Central sketch to use
+    
+    20. Fix Jira 588 - BLE Corrupted Long Write
+         i. Modify the BLECharacteristic to implement the Long write feature.
+    
+    21. Fix Jira 683 Typecasting and Pointers should be avoided in sketch
+         i.   Add write in Characteristic template
+         ii.  Add method in BLE Role class to avoid typecaste
+         iii. Modify the advertise address parameter and related example sketches
+    
+    22. Fix Jira 704 Type Characteristic should be documented
+    23. Fix Jira 684 Documentation about the central/peripheral
+
+[33mcommit ae78b1626ef682331af055075fbddb672cb19552[m
+Author: lianggao <liang.gao@intel.com>
+Date:   Fri Jul 29 22:19:36 2016 +0800
+
+    Add BLE central function, debug interface and refactor peripheral
+    
+    -Add debug interface on Serial1
+    -Update BLE stack and need update BLE's FW
+    -Reconstruct the BLE peripheral base on V3
+    -Implement the BLE Central Role base on V3
+    -Implement some sketches for new BLE library
+    -Add central read/write example
+    -Add set advertising parameter interface
+    -Add API to allow set up advertising after setup
+    -Add interface to set the device name
+    
+    File description
+    Porting from V3
+     system/libarc32_arduino101/common/atomic.h
+     system/libarc32_arduino101/common/misc/byteorder.h
+     system/libarc32_arduino101/drivers/atomic_native.c
+     system/libarc32_arduino101/drivers/bluetooth/att.h
+     system/libarc32_arduino101/drivers/bluetooth/bluetooth.h
+     system/libarc32_arduino101/drivers/bluetooth/conn.h
+     system/libarc32_arduino101/drivers/bluetooth/conn_internal.h
+     system/libarc32_arduino101/drivers/bluetooth/gatt.h
+     system/libarc32_arduino101/drivers/bluetooth/hci.h
+     system/libarc32_arduino101/drivers/bluetooth/uuid.h
+     system/libarc32_arduino101/drivers/rpc/rpc.h
+     system/libarc32_arduino101/drivers/rpc/rpc_deserialize.c
+     system/libarc32_arduino101/drivers/rpc/rpc_functions_to_ble_core.h
+     system/libarc32_arduino101/drivers/rpc/rpc_functions_to_quark.h
+     system/libarc32_arduino101/drivers/rpc/rpc_serialize.c
+     system/libarc32_arduino101/framework/include/util/misc.h
+     system/libarc32_arduino101/framework/src/os/panic.c
+     system/libarc32_arduino101/framework/src/services/ble/conn.c
+     system/libarc32_arduino101/framework/src/services/ble/conn_internal.h
+     system/libarc32_arduino101/framework/src/services/ble/dtm_tcmd.c
+     system/libarc32_arduino101/framework/src/services/ble/gap.c
+     system/libarc32_arduino101/framework/src/services/ble/gatt.c
+     system/libarc32_arduino101/framework/src/services/ble/hci_core.h
+     system/libarc32_arduino101/framework/src/services/ble/l2cap.c
+     system/libarc32_arduino101/framework/src/services/ble/l2cap_internal.h
+     system/libarc32_arduino101/framework/src/services/ble/smp.h
+     system/libarc32_arduino101/framework/src/services/ble/smp_null.c
+     system/libarc32_arduino101/framework/src/services/ble/uuid.c
+     system/libarc32_arduino101/framework/src/services/ble_service/ble_service.c
+     system/libarc32_arduino101/framework/src/services/ble_service/ble_service_api.c
+     system/libarc32_arduino101/framework/src/services/ble_service/ble_service_int.h
+     system/libarc32_arduino101/framework/src/services/ble_service/ble_service_internal.h
+     system/libarc32_arduino101/framework/src/services/ble_service/ble_service_utils.c
+     system/libarc32_arduino101/framework/src/services/ble_service/gap_internal.h
+     system/libarc32_arduino101/framework/src/services/ble_service/gatt_internal.h
+     system/libarc32_arduino101/framework/src/services/ble_service/nble_driver.c
+
+[33mcommit 77d908688e799557fa6e582fbd885c825aaa07c6[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Mon Sep 19 16:48:28 2016 -0700
+
+    Rebuilt libarc
+
+[33mcommit 5340b0c9c1fa02257b7f363339594944f4c6be9e[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Mon Sep 5 15:41:42 2016 +0200
+
+    CurieEEPROM refactor
+    
+    This PR refactors CurieEEPROM library, syncing it with AVR version.
+    Since EEPROM on Curie chip is based on OTP flash storage, the minimum write
+    size is 4 bytes. The current implementation brings some problems like
+    http://forum.arduino.cc/index.php?topic=421348.0 , and the examples are
+    quite broken.
+    
+    The refactor also changes the name, from CurieEEPROM to EEPROM, so code for
+    AVR sketches compiles out of the box. The new library resolution engine
+    (from IDE 1.6.8 onward) handles this perfectly but we can stick to older name
+    if we need compatibility with older IDEs.
+
+[33mcommit 4c69f724b9e253c014e118ca87d031929deea7ca[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Thu Sep 1 15:20:32 2016 -0700
+
+    Added support for Quark I2C interfaces: I2C0 and I2C1.
+    
+    Additions:
+    1.  Ported Quark I2C driver to ARC/CoreLibs, located at system/libarc32_arduino101/drivers.
+    2.  Created the I2C Adapters, located at cores/arduino.
+    
+    Modifications:
+    1.  Platform.h - added number of I2C interface definition.
+
+[33mcommit 7dcc0742ef43174547efec5497359d6d80cc6387[m
+Author: Biagio Montaruli <biagio.hkr@gmail.com>
+Date:   Sat Sep 17 13:45:03 2016 +0200
+
+    Update bus_scan.ino sketch of Wire library
+    
+    Improve documentation, code formatting and use LED_BUILTIN instead of 13
+    to control the on-board led connected to digital pin 13 of
+    Arduino/Genuino 101
+    
+    Signed-off-by: Biagio Montaruli <biagio.hkr@gmail.com>
+
+[33mcommit 23ca972371c3bf9db488e948d35b870a1fa52b2c[m
+Author: Sandeep Mistry <sandeep.mistry@gmail.com>
+Date:   Thu Sep 15 15:22:35 2016 -0400
+
+    WString: add `toDouble` (#293)
+    
+    Port of https://github.com/arduino/Arduino/pull/5362
+
+[33mcommit f818d7cd360e109c31bc65ed11f0df3b133bc826[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Sep 6 14:06:34 2016 -0400
+
+    Make String::move of an invalidated String result in an invalidated String
+
+[33mcommit 2751995ab29738c708b5b7d109d98cbfc34a09e4[m
+Author: Biagio Montaruli <biagio.hkr@gmail.com>
+Date:   Wed Sep 7 13:01:32 2016 +0200
+
+    Fix for USB virtual serial port in sketches of CurieIMU library
+    
+    Since Arduino/Genuino 101 uses USB native port, wait for the Serial port
+    to open before executing the sketch to not lose serial data already sent
+    to the Serial monitor
+    
+    Signed-off-by: Biagio Montaruli <biagio.hkr@gmail.com>
+
+[33mcommit d8d2c495b531fda1ffe98cb59f7e35fd948c5bad[m
+Author: Biagio Montaruli <biagio.hkr@gmail.com>
+Date:   Wed Sep 7 13:05:01 2016 +0200
+
+    Fix for USB virtual serial port in sketches of CurieI2S library
+    
+    Since Arduino/Genuino 101 uses USB native port, wait for the Serial port
+    to open before executing the next lines of code to not lose serial data
+    already sent to the Serial monitor
+    
+    Signed-off-by: Biagio Montaruli <biagio.hkr@gmail.com>
+
+[33mcommit e084140957ebe2aa0d891c496ced456538c9a1b9[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Sep 7 16:02:31 2016 -0700
+
+    stdlib_noniso.cpp: fix dtostrf() handling of integral portion
+    
+    Checking only for > 10 here (rather than >= 10) means that numbers with a
+    leading '10' in the integral portion generate incorrect strings.
+
+[33mcommit b329d080469778b7e9c8e0868ab6edba4a7fdf97[m
+Author: russmcinnis <russ.mcinnis@intel.com>
+Date:   Tue Aug 30 15:56:08 2016 -0700
+
+    add comment to pulseIn() in the header file to warn programmer about trying to detect high frequencies.
+
+[33mcommit 10d1056503099431cda97deacabbb2a68f43121e[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Thu Aug 25 12:47:00 2016 -0700
+
+    Verify BLE FW version on every sketch upload
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 431fb6fd27bdfbd6aaa97e690f1b162a1e02cb62[m
+Author: sys_maker <sys_maker@intel.com>
+Date:   Mon Aug 22 12:35:27 2016 -0700
+
+    Rebuilding libarc32 library
+    
+    Signed-off-by: sys_maker <sys_maker@intel.com>
+
+[33mcommit 0d86ead0d4ae870c32c679fca3ef087c83a758fc[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Dec 3 11:34:56 2015 -0800
+
+    Add flashpack to IDE
+
+[33mcommit 71cf8e44b3d9c28918084c0e5a6c2d1e239b1c98[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Aug 10 13:53:03 2016 -0600
+
+    JIRA-668: Removing Intel version of Adafruit_NeoPixel
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit e4a5b14c51e70933ff3f85603a08c3b6970ec264[m
+Author: Adrien Descamps <adrien.descamps@gmail.com>
+Date:   Sat Aug 6 16:27:35 2016 +0200
+
+    Fix UART receiver corruption
+    
+    When the UART receiver is disconnected for a time shorter than a line break
+    and longer than a start bit, it interpret that as a received packet, and if
+    data are transmitted immediatly after, they are corrupted.
+    This commit is a workarround for that bug, that enable the loopback feature
+    of the UART when UART is disconnected, so the UART module does not notice
+    it is disconnected.
+    A previous workarround for this bug (a forced delay after disconnection) is
+    not needed anymore and is removed.
+
+[33mcommit 7366ed0a4fd26faec64e11b530557c313069b4f7[m
+Author: Adrien Descamps <descampsa@users.noreply.github.com>
+Date:   Wed Aug 3 01:40:57 2016 +0200
+
+    Flush wait for transmission to be complete
+    
+    In previous version, flush wait for the transmission to be complete
+     by checking if the transmission holding register (or fifo) is empty.
+    When this happen, the last byte is still in the shift register,
+    and has still to be transmitted.
+    This mean we can't know when the transmission is actually complete,
+    which is crucial to implement RS485 communication, for example.
+    
+    This commit change this behaviour and wait for the shift register to be empty,
+     which means the transmission is really complete.
+
+[33mcommit 48b0e58306d227b289316fcb4143edb08570042c[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Wed Aug 3 14:16:23 2016 -0700
+
+    Update libarc to the latest
+
+[33mcommit 9ae91d3e9d55d81358681dd1595880de1176d640[m
+Author: unknown <jysholar@jysholar-MOBL.amr.corp.intel.com>
+Date:   Tue Aug 2 09:49:30 2016 -0600
+
+    Jira-556: Add comments to I2S examples
+
+[33mcommit b317284ec9312288dea4e2b5db5696821fa6237f[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Thu Jul 28 10:44:44 2016 -0700
+
+    Update libarc to the latest
+
+[33mcommit 9a871b671ceec5f625c63c9a9e58f044cef2e70c[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Jul 27 14:20:29 2016 -0700
+
+    Add delay to Serial1.end() allow GPIO lines to settle
+    
+    Through testing, it was discovered that if Serial1.begin() is called again
+    immediately after Serial1.end(), then any attempt to write data immediately
+    following the begin() call could result in corrupted frames.
+    
+    After calling Serial1.end(), it will be at least 300us before those pins can
+    be used as UART again.
+
+[33mcommit e3d90c19d96bbab006f59151b73179ab0c7d9097[m
+Author: Caihong Ma <caihong.ma@intel.com>
+Date:   Tue Jul 26 01:34:39 2016 +0800
+
+    CurieI2SDMA: Fix typo and add explanatory notes
+    CurieI2SDMA.h: Fix typo at line 23 and 24; I2SDMA_RXCallBack.ino: add
+    explanatory notes to explain how to check the verification of data
+
+[33mcommit fbb7b02a89da37ac9408710ff5ed1a936d00cd8b[m
+Author: Xie,Qi <qi.xie@intel.com>
+Date:   Tue Jul 19 09:13:39 2016 +0800
+
+    JIRA-640 I2C operations are sometimes timing out causing a long delay in between i2C operations
+    
+    fix this issue by call complete callback if no stop command issue at the end
+    of transfer.
+
+[33mcommit 160751a8c47f1d4cdd647ad1bf0d8eb6312d5791[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Fri Jul 22 18:21:27 2016 -0700
+
+    README.md: add "commit message how-to" wiki link
+
+[33mcommit 197434001a973ad7a8df18b823f8365988140b43[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Sun Jul 17 00:33:17 2016 -0700
+
+    Issue #149: Provide scaled IMU data
+    
+    Add implementations of readAccelerometer and readGyro which
+    return values that are scaled according to the range set with
+    setAccelerometerRange and setGyroRange
+
+[33mcommit 5671917298c35e6164784da6929cf006daf9d51d[m
+Author: caihongm <caihong.ma@intel.com>
+Date:   Fri May 27 02:17:19 2016 +0800
+
+    Jira509:add IMU examples:FreeFallDetection, MotionDetection,ZeroMotionDetection; change CurieIMU.cpp line490 from 'setZeroMotionDetectionThreshold' to 'setZeroMtionDetectionDuration'
+
+[33mcommit 12b2376ea58c79ef00ea47af2aea8796bb652d69[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Wed Jul 20 15:23:23 2016 -0700
+
+    ATLEDGE-643: Add chip ID to SerialFlash example sketch
+    
+    RawHardwareTest reports the 101's on-board SPI flash chip as an unknown
+    device. Fix this by adding the device's JEDEC ID to the example sketch.
+
+[33mcommit b8162e993cccbe4065c1bd55d1f4466669f01f75[m
+Author: Caihong Ma <caihong.ma@intel.com>
+Date:   Mon Jul 4 15:15:54 2016 +0800
+
+    Jira566: I2S DMA implement: supplement library and example
+
+[33mcommit c59e2808e1bf27e8adc7c3aff0d0ed1a8344e04f[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Fri Jul 15 15:39:16 2016 -0700
+
+    Issue #241: make Serial1 release GPIO pins on end()
+    
+    UARTClass::init() muxes out the UART pins to Arduino header pins 0/1.
+    Reset the mux on UARTClass::end() so that pins 0/1 can be used as GPIOs
+    again.
+
+[33mcommit bdaec192070ab196a55282fa57512748c6f1edd9[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Mon Jul 11 11:21:34 2016 -0700
+
+    Add CurieIMUClass::end()
+    
+    Add end() method to IMU class, to disable clocking to the SPI
+    controller. This is unlikely to have noticeable power-saving effects,
+    however it is a good habit to get into.
+
+[33mcommit 2ec9b94f941d34ee1419311b194707aad3b0ee67[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Jul 11 14:47:59 2016 -0700
+
+    Update Wire examples to use Serial instead of Serial1
+    
+    -change Serial to Serial1 in the master_writer and master_reader
+    examples
+
+[33mcommit 5f3ee5bb36dc5e69ce26f7d2a64220ebc927ad83[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Jul 12 10:22:12 2016 +0200
+
+    define digitalPinToInterrupt for backwards compatibility
+    
+    see http://forum.arduino.cc/index.php?topic=370167.0
+
+[33mcommit ecee2e9483e39af71df873174df070fdf952c431[m
+Author: Caihong Ma <caihong.ma@intel.com>
+Date:   Mon Jul 4 15:15:54 2016 +0800
+
+    I2S DMA - supplement library and examples
+
+[33mcommit 3168ede2cbd3df99121944d46a5b24e9557d2b4b[m
+Author: erik.nyquist <eknyquist@gmail.com>
+Date:   Fri Jun 24 13:08:25 2016 -0700
+
+    ATLEDGE-619: fix dtostrf
+    
+    Use a different method for float->string conversion, and
+    fix the width calculation so that extra spaces are only
+    printed if the width parameter exceeds the output string
+    length (ie. a mininum width, as specified by dtostrf
+    reference from avr-libc).
+
+[33mcommit 019bb8fcecc1c79d78bd58f18f1b4521e73fad35[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Jun 24 14:58:48 2016 -0700
+
+    update libarc32
+    
+    -update libarc32 binary
+
+[33mcommit 9be7604bec5f080683a236cbabfe0d70b174ac13[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Apr 20 14:52:22 2016 -0700
+
+    I2C - add functionality to change i2c clock speed
+    
+    -adds functionality to change clock speed
+    -clock speed is set/changed when Wire.begin() is called
+    -default is standard mode
+    -use Wire.begin() for standard speed (100k)
+    -use Wire.begin(I2C_SPEED_FAST) for full speed (400k)
+    -use Wire.setClock(I2C_SPEED_FAST) for full speed (400k)
+
+[33mcommit 8682149177559757a57ae0b2ad6639dcf97e31b1[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Jun 24 14:33:45 2016 -0700
+
+    reduce i2c delays
+    
+    -reduce i2c delays to increase performace without changing the timeout
+    threshold
+
+[33mcommit de0650c15a0d44284440e4c4ba1943639b73da4f[m
+Author: erik.nyquist <eknyquist@gmail.com>
+Date:   Tue Jun 28 15:21:32 2016 -0700
+
+    Add -std=gnu11 to compiler.c.flags in platform.txt
+    
+    Related to issue #221
+
+[33mcommit 4d9642871ae0bfb28783b1d6fa00b364ea201cf1[m
+Author: Oren Levy <oren@auxren.com>
+Date:   Mon Jun 20 14:59:09 2016 -0700
+
+    Added MIDI examples
+
+[33mcommit 2cd33f43a1b84c3f23194b27290114c4cec5d9df[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Thu Jun 16 11:29:06 2016 +0200
+
+    Correct core version in platform.txt
+
+[33mcommit 20844ff46b455055f86641c785fb580ae1214222[m
+Author: Mike Duong <mike.hx.duong@intel.com>
+Date:   Wed May 25 18:32:05 2016 -0700
+
+    ATLEDGE-586: String.compareTo() does not compute the same as Uno for POS values
+
+[33mcommit 2f5ae85f235bc1e5a0e5b50d63961f4348f237a0[m
+Author: erik.nyquist <eknyquist@gmail.com>
+Date:   Mon Jun 13 10:35:53 2016 -0700
+
+    ATLEDGE-572: Fix getStepDetectionMode()
+    
+    This function is reading all 8 bits of RA_STEP_CONF_1 (0x7A-0x7B)
+    to obtain a value for min_step_buf, though this value is only
+    represented by the lower 3 bits; bit 4 is used as the 'enable' bit.
+    As a consequence, this function will read the step detection mode
+    incorrectly when step counting is enabled. Fix this by only reading
+    the lower 3 bits of RA_STEP_CONF_1.
+
+[33mcommit de30a61b909802f2dbb3380c4adc9316ee1f64f7[m
+Author: erik.nyquist <eknyquist@gmail.com>
+Date:   Mon Jun 13 11:57:21 2016 -0700
+
+    ATLEDGE-553 Modify library examples header info
+
+[33mcommit a694d09698db8d0f77ac19d58d1db34eef3d1b4d[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Tue Jun 7 16:57:12 2016 -0700
+
+    Jira-617: String Object constructor hangs up when handling large floating point number
+
+[33mcommit df3b675c1ba4113fa560078ae60f610f4d8b3ae0[m
+Author: Erik Nyquist <eknyquist@gmail.com>
+Date:   Fri Jun 3 15:02:00 2016 -0700
+
+    SerialFlash: enlarge chip ID buffer
+    
+    SerialFlashChip::readID() writes up to 5 bytes into
+    the buffer provided, but the caller only allocates
+    3 bytes. Increase buffer size to 5 bytes.
+
+[33mcommit c27462cbc168257c2c928d435dcaf3b43a535fe1[m
+Author: Xie,Qi <qi.xie@intel.com>
+Date:   Wed May 25 07:30:23 2016 +0800
+
+    JIRA-560 I2C Bus Scan
+    using read instead of write to avoid sending the extra byte when scaning I2C bus
+
+[33mcommit e792ba2bd6480a556e50259e0e836ae4cf5ec371[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue May 31 17:03:06 2016 -0700
+
+    Fix bug when using StringConstructor with doubles
+    
+    -Fixes issue of StringContructor instability with doubles
+
+[33mcommit acc4b38ba43d654992b72fa9d4afa68b834a098c[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue May 31 16:12:32 2016 -0700
+
+    Revert "Fix some issues with printing float and double"
+    
+    This reverts commit b8ea343bb237762de6ee3a60ba0b1e8d5af12ff0.
+
+[33mcommit 409e4b07f477e6345c972a40376085c89ecdb46e[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Fri May 27 14:38:05 2016 -0700
+
+    Remove unsupported SerialFlash example
+    
+    CopyFromSD.ino requires SDfatlib (for AVR boards) which
+    is unsupported.
+
+[33mcommit 4294ca5ad86c2f7f5cfb354ac193ff1ecbfc9fa9[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Fri May 27 14:36:36 2016 -0700
+
+    Remove SPI.set* calls from SerialFlash example
+    
+    These functions are not implemented for A101's SPI library.
+    Remove these calls from examples/CopyFromSerial.ino
+
+[33mcommit f33e362db41f7871a63bc8f0294ce9aa43be3f0d[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Fri May 27 14:26:46 2016 -0700
+
+    Add category to Wire/library.properties
+
+[33mcommit 348e36ee6e6eb2c5f5687b642f978aabcace5be2[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Thu May 26 15:54:08 2016 -0700
+
+    Jira-602: Convert float and double to strings.  Output string is padded with spaces.
+
+[33mcommit ce7825883b79bd6849cc1fba4bbaa6416e43229d[m
+Author: caihongm <caihong.ma@intel.com>
+Date:   Fri May 27 02:17:19 2016 +0800
+
+    Jira509:add IMU examples:FreeFallDetection, MotionDetection,ZeroMotionDetection; change CurieIMU.cpp line490 from 'setZeroMotionDetectionThreshold' to 'setZeroMtionDetectionDuration'
+
+[33mcommit b8ea343bb237762de6ee3a60ba0b1e8d5af12ff0[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu May 26 13:51:06 2016 -0700
+
+    Fix some issues with printing float and double
+    
+    -fixes some issues with printing float and double
+    -limits the number of decimal places printable to 16
+
+[33mcommit 9472c9aa9427030f3e24968d4915fdf69881ea66[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed May 25 15:43:28 2016 -0700
+
+    Remove unnecessary #undefs
+    
+    -Remove #undefs from CurieSoftwareSerial Library
+    -Because it was braking some functionality such abs()
+
+[33mcommit 048800b47b8edcbe0cbf9401163ace1f4c15bb3e[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Thu May 19 11:36:38 2016 -0700
+
+    Jira-599.  Routine, dtostrf, did not work with the latest toolchain.  The call to sprintf in the routine crashed the system.  Issue corrected by replacing the call.  The routine, printfloat, in Print.cpp, is now usint dtostrf to print out double and float values.
+
+[33mcommit 874c3ef08bf7031a06248abbb59274da740444f2[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Fri May 20 10:38:55 2016 -0700
+
+    SPI: add SPI1 to keywords.txt
+
+[33mcommit 92818058e83302e478e7cdddd60d1d5568ce9bc5[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Thu May 19 10:34:30 2016 -0700
+
+    Add Paul Stoffregen's SerialFlash library
+
+[33mcommit 8dea7b4a1430dce33870a97fcf0330e0cda4fef3[m
+Author: erik.nyquist <enyquist@geronimo.amr.corp.intel.com>
+Date:   Mon May 16 10:41:02 2016 -0700
+
+    Fix SPI clock divider calculation
+    
+    If a clock value greater than the maximum supported
+    is passed (i.e. > 16MHz), the resulting value written
+    to the BAUDR register will be 0 which will disable
+    the serial output clock. Check for this and ensure
+    the value calculated for BAUDR register is never < 2.
+
+[33mcommit 331b2f0152bb90f1c96ee1726e8017db56e51789[m
+Author: erik.nyquist <erik.nyquist@intel.com>
+Date:   Thu May 12 11:18:35 2016 -0700
+
+    Clean up the SPI files
+    
+    Be consistent about commenting style, and
+    stay below 80 chars where appropriate.
+
+[33mcommit 2bb742afd2e8cf0a3708b3b50a94089b5b39a3a8[m
+Author: erik.nyquist <erik.nyquist@intel.com>
+Date:   Thu May 12 11:15:04 2016 -0700
+
+    Add support for SPI1 device to SPIClass
+    
+    SPI1 can now be used (SPI1.begin()) to access
+    the SPI device connected to the Arduino 101's
+    on-board SPI flash device
+
+[33mcommit 2bea587379b0e78d4006db13e4c9bdf4482637c0[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Mon Apr 25 15:36:38 2016 -0600
+
+    JIRA-550 Retain unstripped ELF file for debugging
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit ea7a804cefdf17a7518ba8c3fec95bb744273d0c[m
+Merge: 2b5a040 9f88024
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed May 11 14:09:23 2016 -0600
+
+    Merge pull request #172 from bbaltz505/new_toolchain
+    
+    Updating compile command and driver lib for new toolchain
+
+[33mcommit 2b5a0402af9486f527805124a5ef937cbfb89ee1[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Fri May 6 16:39:36 2016 -0700
+
+    Bug fixed: CurieBle library, class BLECharacteristic allocates memory using an incorrect variable which may result in memory corruption if the memory size is bigger than 16 bytes.
+
+[33mcommit cdd2989b4297c10c8759de408ccb021f0874763a[m
+Author: jysholar <janet.y.sholar@intel.com>
+Date:   Mon May 9 12:48:48 2016 -0600
+
+    CurieIMU tap/double example, JIRA-508
+
+[33mcommit 434fcd49ddcae18726b8196153baf0a68882b55e[m
+Author: erik.nyquist <erik.nyquist@intel.com>
+Date:   Tue May 10 11:41:19 2016 -0700
+
+    README.md: clean up and add "support" section
+    
+    Break long lines to be <= 80 chars, where possible, and
+    add a new section to guide users to the appropriate place
+    for support (Arduino forum for product support, issue
+    tracker for bugs & features).
+
+[33mcommit eb0cf4f1ceaa0fc4220adcc726063e17934eee3e[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Wed May 4 10:28:22 2016 +0200
+
+    Add SERIAL_PORT_USBVIRTUAL and SerialUSB macros
+    
+    This is needed to ensure compatibility with YunShield sketches
+    
+    asas
+
+[33mcommit 9f880240e6cb1deba4c8bd3f296dff4eb5a54929[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Thu Apr 28 15:33:58 2016 -0700
+
+    Updating compile command and driver lib for new toolchain
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 2bac6d3432033197ffc23c6da96ddd99054271f9[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon May 2 15:59:10 2016 -0700
+
+    Fixed the license file to LGPLv2.1
+
+[33mcommit 443916f2621a808540997f36caa9bcd2c9d7fb5f[m
+Merge: f43789e c1be134
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon May 2 14:54:12 2016 -0700
+
+    Merge pull request #156 from bigdinotech/i2slib
+    
+    CurieI2S library
+
+[33mcommit f43789e71bcc9c7d8181aec61c48eed3a9683cba[m
+Author: jysholar <janet.y.sholar@intel.com>
+Date:   Tue Apr 26 12:25:01 2016 -0600
+
+    Jira-560, getInterruptStatus(...) should return type of bool
+
+[33mcommit 212dae55ea664d1bd92ad175615a49bec7d1bc4f[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Apr 5 09:50:36 2016 -0400
+
+    Sync avr/pgmspace.h entries with SAMD core
+
+[33mcommit 7bd93b3baf802481282e32240fcfc1f941e36561[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Thu Apr 14 15:46:58 2016 -0700
+
+    Jira-584: String constructor create floating point string with incorrect number of decimal places.
+
+[33mcommit 4d1014ff2b89a88f9605e2cb7f75bbe7bd0691e4[m
+Author: russmcinnis <russ.mcinnis@intel.com>
+Date:   Wed Apr 13 11:10:56 2016 -0600
+
+    check pin range first thing in pinMode(), digitalWrite() and digitalRead()
+    
+    Signed-off-by: russmcinnis <russ.mcinnis@intel.com>
+
+[33mcommit 285ec1770d831f584ca943f2e4d214ad59e35ffe[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Apr 12 10:56:38 2016 -0600
+
+    Removing obsolete TFT library
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit e9aaea9b39eb1496ebccdef422ae2d441f9086f4[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Fri Apr 8 15:11:42 2016 -0600
+
+    Fix CurieTimerOne example filename
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 4cad8b8e31d7e8f13b394e90ffa2253ffb0d5f9b[m
+Author: russmcinnis <russ.mcinnis@intel.com>
+Date:   Wed Apr 6 13:30:42 2016 -0600
+
+    pwmStop() leaves pin HIGH
+    
+    pwmStop() was doing a digitalWrite(pwmPin, LOW) after the kill() so unless the pin happened to be 0 the pwmPin might be left in the HIGH state causing motors or other devices to run HIGH after pwmStop(). Just removed the pwmPin = 0 from kill() and it passes all our loopback tests.
+
+[33mcommit 0e4a0d439341781ef6709b73d45a77c79cdf0de7[m
+Merge: 669fb9b 0ad15b5
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Apr 5 09:23:41 2016 -0600
+
+    Merge pull request #146 from bneedhamia/support-eddystone-url
+    
+    Added Eddystone-URL support
+
+[33mcommit 669fb9bcf6e80d774a8a9d836b3354c5ddd04a99[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Mon Apr 4 15:55:55 2016 -0600
+
+    JIRA-558 Remove Intel Ethernet and SD libraries
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit c1be134976c7afa8fd3af95907e0f043efc6bc8d[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Apr 4 10:17:29 2016 -0700
+
+    CurieI2S - minor fixes/improvements
+    
+    -prevent buffer overflow in I2S_RxCallback example
+    -calculate delay for any sample rate
+
+[33mcommit 0ad15b5a46969ddda239cf764caebb32a81e56ae[m
+Author: Bradford H. Needham <bneedhamia@gmail.com>
+Date:   Sun Apr 3 11:07:14 2016 -0700
+
+    Fixed spaces in keywords.txt; keywords now highlight properly
+
+[33mcommit 89dd2287dfd41a12db0a34eed7d94b8593b2e5da[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Apr 1 12:06:36 2016 -0700
+
+    CurieI2S add examples
+    
+    -add basic examples using callback functions/interrupts
+    -add callback function to fill tx buffer
+
+[33mcommit 2bca6fc912b51200ad12b833e52321e65ccf553b[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Mar 30 12:18:36 2016 -0700
+
+    Interrupt based I2S library
+    
+    -CurieI2S using interrupts
+
+[33mcommit a54f5132630fb2825e27d84cf4ddf3d8ee22192a[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Thu Mar 31 11:50:12 2016 -0700
+
+    Jira-575, Jira-506:  Bug fixes to print float and double correctly, in a string or std output.
+
+[33mcommit ccc02128ad2371d3ed35ebb3a01d4146df930e97[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Mar 23 18:07:38 2016 -0700
+
+    CurieI2S use interrupts for Tx
+    
+    -Use interrupts to fill FIFO buffer from TX buffer
+
+[33mcommit 4fae4ddb4cc9bb14c6c4ccc6147253944c778bb9[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Mar 8 15:01:49 2016 -0800
+
+    CurieI2S initial commit
+    
+    - Minimal functional version
+
+[33mcommit 2eb99d10a116a092a2ade78a79d96d164847f9b2[m
+Author: agdl <a.guadalupi@arduino.cc>
+Date:   Fri Mar 11 13:58:24 2016 +0100
+
+    Removed delay from examples as requested by Tom
+
+[33mcommit 38a508e4552f88649cdd664babd0165673b7caa6[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Tue Mar 8 13:31:14 2016 -0800
+
+    Jira-528.  Make CurieTimerOne library to be compatible with the TimerOne library originated from Paul.  Created methods that have the same name and functionalities as in the TimerOne library.
+
+[33mcommit 98ee736fa2bb12e99d80bad866a9a298e0bc1c2e[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Mon Mar 14 18:01:40 2016 +0100
+
+    Update CurieTimer1Interrupt.ino
+    
+    Changed the style of the code according to Arduino's Tutorials guidelines.
+
+[33mcommit 40d3fb07d98db264dc1f2b0c2b5a3057359a721d[m
+Author: Bradford H. Needham <bneedhamia@gmail.com>
+Date:   Tue Mar 8 20:35:51 2016 -0800
+
+    Added Eddystone-URL support: added setAdvertisedServiceData() to support BLE Service Data; changed Incomplete to Complete Service UUID list code in Advertising initialization, required by Eddystone-URL protocol; added (for debugging) getAdvertisingLength() and getAdvertising() to enable a Sketch viewing the Advertizing packet.
+
+[33mcommit 17eac79d76b721eb116179aa87f0e3627add4927[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Mar 8 10:54:11 2016 -0800
+
+    Fix Klockwork issues in CurieEEPROM #142
+    
+    -Also fixes issue of not being able to rewrite the last 3/4 of the
+    EEPROM area
+
+[33mcommit e50ef904347f9d4da0a7c4e0e5523b4ff5d040bb[m
+Merge: 1f3899a c7b30f4
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Mar 8 11:51:38 2016 -0700
+
+    Merge pull request #141 from bbaltz505/memory_size
+    
+    Fixing sketch size calculation (text + ctors + rodata + datas
+
+[33mcommit c7b30f4c627ad20b5cdbc621803afa76fba61bfd[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Mar 8 07:07:43 2016 -0800
+
+    Decrease max sketch size to 155,648 bytes
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit f02410e9bf138f48243b62853b44c9b797ea01e9[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Feb 24 20:04:14 2016 -0800
+
+    Fixing sketch size calculation (text + ctors + rodata)
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 1f3899a7cabd71ae9fbda7f721a117614587adaa[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 22:29:38 2016 +0100
+
+    Update library.properties
+
+[33mcommit c4a20140569016649b4333ef6c349c8041827164[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 21:55:23 2016 +0100
+
+    Update library.properties
+
+[33mcommit 72b85b2bdb884a995620e3aeb66d518844b0746a[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 21:39:55 2016 +0100
+
+    Update library.properties
+
+[33mcommit 3d019ed2cebf9034e37cda961d16b08042d8f731[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 21:34:23 2016 +0100
+
+    Update library.properties
+
+[33mcommit 5bb196cdd961a0fb54129d1fcf2fc99778ab0914[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 19:58:12 2016 +0100
+
+    Update library.properties
+
+[33mcommit fda58303cb959000bb8d04855f5b11838423d15d[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 19:35:08 2016 +0100
+
+    Update library.properties
+
+[33mcommit 7905133b686bf5dcc0112b828a9d8128ddf6ee8e[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 19:24:32 2016 +0100
+
+    Update library.properties
+
+[33mcommit bc9c387332dc16290f1c1c180eabae0d33eec8fe[m
+Author: SimonePDA <majocchi@aquariusedizioni.it>
+Date:   Thu Mar 3 19:12:32 2016 +0100
+
+    Update library.properties
+
+[33mcommit 953479ae0f37961fb8f4040fbdcd8848f59cae33[m
+Merge: 3bd268c eacb1bd
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Mar 2 15:06:03 2016 -0700
+
+    Merge pull request #129 from 00alis/src_folders
+    
+    Moved .h and .cpp file in src folder
+
+[33mcommit 3bd268c3992f095233bb16a18dac8541b86b0bf2[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Mar 2 10:40:59 2016 -0800
+
+    Updating install steps in README
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit eacb1bd114ec57cbecab357dfab8a396b5e7b09d[m
+Author: Alice Pintus <a.pintus@arduino.cc>
+Date:   Wed Mar 2 12:49:10 2016 +0100
+
+    Rename library.properties
+
+[33mcommit 1cbd80b226b237ddb5a2cd5705f63975ed6f9596[m
+Author: Alice Pintus <a.pintus@arduino.cc>
+Date:   Wed Mar 2 11:56:24 2016 +0100
+
+    Moved .h and .cpp file in src folder
+
+[33mcommit e8b8a5db546696735d5de38e58253b75cb411e7a[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Feb 26 15:05:54 2016 -0500
+
+    Change set/get accelerometer and gyro offsets to use floats values
+    
+    This makes it consistent with other API changes to convert the register
+    values to floats and vice versa.
+
+[33mcommit ffc51eff1581f38c977798114f94affc5393d0e2[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Feb 2 10:08:35 2016 -0500
+
+    Add setConnectionInterval API to CurieBle
+
+[33mcommit f11de80d789e9071a05387cfa96d80e08db563cc[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Feb 23 15:06:09 2016 +0100
+
+    use sprintf-based implementation for dtostrf
+    
+    altough the current implementation passed all the unit tests, an user reported problems with the actual code (http://forum.arduino.cc/index.php?topic=380422.0).
+    If libc has float support there is no need to do strange things like on AVR, so we can use the sprintf implementation
+
+[33mcommit ad1586ef179fa0920edb29d4e3a05307a267a3cd[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon Feb 29 15:14:32 2016 -0800
+
+    Updated README.md with instructions to manually install corelibs
+
+[33mcommit 582d03353b5111b8030ec5a6954ec480acaaa6d3[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Feb 26 11:04:59 2016 -0800
+
+    i2c bus scan workaround
+    
+    -sends a byte of value 0 when doing an i2c bus scan
+
+[33mcommit f6d8aa81847643f1102805e9b1f6ef32c3fbc0a9[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Feb 22 14:08:34 2016 -0800
+
+    CurieEEPROM - ensure 32-bit allignment
+    
+    -ensure 32-bit address allignment for put(), get(), read(), and write()
+
+[33mcommit 64ee87970db858c1e4caed63e41f21158f6653b7[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Feb 24 17:45:23 2016 -0800
+
+    Remove custom Adafruit_Motor_Shield_V2 library
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 6f9739fac258c812f74139c16017817aa4045ace[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Thu Feb 18 17:16:09 2016 -0700
+
+    Use Go-based upload script
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 83bb5f5d818a3ed2db05a0b784c6888822d3e2e7[m
+Author: jysholar <janet.y.sholar@intel.com>
+Date:   Tue Feb 23 10:33:17 2016 -0700
+
+    Rename CurieTimer to CurieTimerOne for JIRA-532
+
+[33mcommit 3448d230240682d1579b26e6f095afe479d68a09[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Wed Feb 17 08:37:19 2016 -0500
+
+    Remove enums for ranges and duration, auto calibrate/set offset now enables offset, rename interrupt routines to interrupts/noInterrupts
+    
+    keywords.txt updates
+
+[33mcommit 63a01dd918a1fd16d7a914dfd312c763699abdde[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Feb 2 11:40:38 2016 -0500
+
+    Rename CurieBle to CurieBLE
+
+[33mcommit e82fe904dba101da79bbd7dd63060f223d8716cc[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Fri Feb 5 11:55:00 2016 -0800
+
+    Jira-507 and 514: 1. Bug corrected in timer ISR where the clearing of the pending interrupt was at the entrance instead of exit.  When interrupts could happen fast enough to put the ISR in a loop. 2. The overhead for the s/w pwm code is 4-5 usec.  Thus, limited the shortest pwm pulse to 10 usec (high and low).
+
+[33mcommit 2299da2693c0fe867c7b90d998b43c15d666e763[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Feb 10 07:47:38 2016 -0800
+
+    Stop interrupt when switching to 100% duty cycle
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit da68b6fcd5363a5b771e02ec7fa4ab1774286ebe[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Feb 3 12:10:41 2016 -0800
+
+    ATLEDGE-516 Stop callback when setting duty cycle to 0
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit ef62ce6bff2c6059e1f0750c8fa2ec9af424f712[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Feb 3 12:09:33 2016 -0800
+
+    Fix pwmStop typo in keywords.txt
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 6059a142b0bed4bd3b1a2e2c45a298bc72ee6754[m
+Author: agdl <a.guadalupi@arduino.cc>
+Date:   Tue Feb 2 15:13:42 2016 +0100
+
+    Fixed define
+    
+    To be compliant with all the others
+
+[33mcommit 65f3b2887bfc3dfe228a3216a4c8b4a4e51dcfac[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Feb 2 11:32:00 2016 -0800
+
+    CurieEEPROM eeprom_write example
+    
+    -increment eeprom address at the correct location so it matches the read
+    example
+
+[33mcommit 6885cded61c1dac1e45d4a33436da6c840994cc4[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Jan 27 14:39:40 2016 -0800
+
+    CurieEEPROM reimplement put and get to not use STL
+    
+    -reimplement put() and get() to not use STL due
+    to incompatibility with max() and min() macros
+
+[33mcommit 0a382340a0487691627ad3af48bce01572029b4b[m
+Author: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+Date:   Wed Jan 27 15:06:53 2016 -0800
+
+    Green pixel fix
+    
+    JIRA: ATLEDGE-470
+
+[33mcommit a6381cb123d77d3da630eda19c5d2947c1e129c6[m
+Merge: 07a53ab 555c23b
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Jan 26 17:05:08 2016 -0700
+
+    Merge pull request #109 from SidLeung/master
+    
+    Jira-501: CurieTimer.resume() did not re-enable interrupt at the controller.
+
+[33mcommit 555c23bc7cabc7217818b18a267a490d01fa63ad[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Tue Jan 26 15:46:33 2016 -0800
+
+    Jira-501: CurieTimer.resume() did not re-enable interrupt at the controller.
+
+[33mcommit 07a53ab9f5174153967e1ebdac7527b680ec6232[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 26 14:13:15 2016 -0800
+
+    CurieSoftwareSerial remove non-working example
+    
+    -Remove non-working TwoPortReceive.ino example
+
+[33mcommit 0eca3b32f09a30c0d146f5730d29f91527836108[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Fri Jan 22 15:07:03 2016 -0800
+
+    Jira-500.  Corrected typo error.  Routine, pwdStop, is now named as, pwmStop.
+
+[33mcommit 02c960487caaaea5e77ca2370af73b59064f442a[m
+Merge: 8a517b6 1be5b6c
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Jan 21 14:03:13 2016 -0800
+
+    Merge pull request #103 from pricopb/master
+    
+    Remove OneWire and Adafruit_DotStar libraries.
+
+[33mcommit 8a517b656072e22b9394ec58b6ee22e179a39789[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Jan 20 15:08:42 2016 -0800
+
+    CurieSoftwareSerial timing issue fixes
+    
+    -fix some timing issues with slower baud rates
+
+[33mcommit aaa453d00cf6e06f36dbe5c9012b252ebbcc9170[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Jan 19 14:17:18 2016 -0800
+
+    ATLEDGE-491 - rename sketchUploader tool to arduino101load
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 4932616c873d7b06af99698214a718f572a404f6[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 19 15:53:12 2016 -0800
+
+    CurieEEPROM fixes
+    
+    -remove leftover debug prints
+    -put() and get() should only support 32-bit alligned addresses
+
+[33mcommit effd880b1cae45f923fabcd8582e86544288ed26[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Jan 7 15:17:40 2016 -0800
+
+    CurieSoftwareSerial Improvements
+    
+    -changed global variables into static
+    -allow different baud rates for different instances of a SoftwareSerial object
+    -minor code cleanup of unused code
+    -moved source code into src directory
+
+[33mcommit 1be5b6cb91fa5f6de5749fa1268f03606f6a83f9[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jan 15 08:32:32 2016 +0000
+
+    Remove OneWire library.
+    
+    Remove the OneWire library because the code changes for porting it to
+    Arduino101 were pushed to Paul Stroffegen's repository:
+        https://github.com/PaulStoffregen/OneWire/commit/e21914433ec588a23922099fa4435fbe0493e5ab
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 1253ea89e0d81b943a1e22aad79559913ea2e297[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jan 15 07:38:11 2016 +0000
+
+    Remove Adafruit_DotStar library.
+    
+    Arduino101 specific changes moved to Adafruit github repository:
+    https://github.com/adafruit/Adafruit_DotStar/commit/0fce0fe52956a7eaf8f29ecfbaecc4138e958ed5
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit ef9d032bf468a09a6921ce4334aa50c1ac227e9c[m
+Author: sys_maker <sys_maker@intel.com>
+Date:   Fri Jan 8 15:56:10 2016 -0800
+
+    Rebuilding libarc32 library and hard-coding tools version
+    
+    Signed-off-by: sys_maker <sys_maker@intel.com>
+
+[33mcommit cc7cccc85afe0fe9c558913305c0ffe86b213caf[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Fri Jan 8 13:27:59 2016 +0000
+
+    find() missing overload in Stream.h
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit b0531afe05cb8e5f301f04e9a207b7fcbb00c93b[m
+Author: Alice Pintus <a.pintus@arduino.cc>
+Date:   Fri Jan 8 11:41:36 2016 +0100
+
+    Update boards.txt
+    
+    Change name Arduino 101 into Arduino/Genuino 101 to be consistent with the rest of the ecosystem
+
+[33mcommit 3ca20d94b362264b0e9ddac74c3731c1ab26a467[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Jan 5 14:06:21 2016 -0800
+
+    ATLEDGE-487 CurieEEPROM library
+    
+    -Initial commit for CurieEEPROM library
+    -Implements EEPROM functionality using an available area of the ROM
+    -supports both BYTE and DWORD reading/writing
+
+[33mcommit b19562438ca48b50a4e505d786d522900d9300fd[m
+Merge: 23e6f16 6fc749d
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Wed Jan 6 15:45:42 2016 -0800
+
+    Merge pull request #90 from sandeepmistry/imu-api
+    
+    Add new API's and examples to CurieIMU
+
+[33mcommit 23e6f16a539bfc4b3fef5b76e1787a66d3966a76[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Mon Dec 21 12:12:18 2015 -0800
+
+    Jira-462: Call Available() after calling end() indicated data available.
+    
+    Code Modifications:
+    
+    1.  Added checking of device open in these routines: available, read, peek.
+        Will return 0 or -1 if device is not opened to indicate invalid operation.
+
+[33mcommit 46519997e46f5088d627e537086cab14e8e14e6d[m
+Author: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+Date:   Tue Dec 22 16:55:54 2015 -0800
+
+    dtostrf: fix overflow problem
+    
+    JIRA: ATLEDGE-315
+
+[33mcommit 6fc749d08dfe770992fe3f50d3073260960c98d9[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 13:46:04 2015 -0500
+
+    Remove calibration steps from accelerometer and gyro examples
+
+[33mcommit af28e53e5b3280f4188cc2c379bacf24cd454bb7[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 13:43:50 2015 -0500
+
+    Use int for accelerometer and gyro API's instead of short
+
+[33mcommit c84af94b39a1efbf3afee132ac49469935b0aa7e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 13:32:14 2015 -0500
+
+    Remove call to setIntEnabled, attachInterrupt enables interrupts
+
+[33mcommit 44fe3307074cb4f5648dbba5718f893b7a4098f4[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 12:10:45 2015 -0500
+
+    Rename CurieImu to CurieIMU
+
+[33mcommit 6557caf258f6d4cef6048036a6cdf15c4fa2a882[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 11:37:59 2015 -0500
+
+    Add accelerometer orientation example
+
+[33mcommit a50c6b649f093f6d5dbb19e9e376f700976b833e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 11:12:32 2015 -0500
+
+    Update example header
+
+[33mcommit 7e628f15227d24c81c4f42bfe1f3cb351bdb8f78[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 11:12:16 2015 -0500
+
+    Initial gyroscope example
+
+[33mcommit cfd445144984d9aaaf3995f257cc5db0e14f04af[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 10:57:14 2015 -0500
+
+    Correct typo in example, az was printed instead of ax
+
+[33mcommit e8a13f7c205de09fa50e90946e9634ef0d6e1562[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 10:52:38 2015 -0500
+
+    Add accelerometer only example
+
+[33mcommit c45ece5a1392b6f0cc7cfdd202b11cc1f87e9d30[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 21 10:50:17 2015 -0500
+
+    Rename readAcceleration and readRotation API's to readAccelerometer and readGyro
+
+[33mcommit 162e0cfbbde7b3e7b8c63daa9444507c02917cbe[m
+Author: Sidney Leung <sidney.leung@intel.com>
+Date:   Tue Dec 15 11:12:47 2015 -0800
+
+    Jira-32 and Jira-386. CurieTimerOne lib
+
+[33mcommit 1e30828bac4a73ef240f1bf8df8aa5e1a2ff1ff3[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 17:46:47 2015 -0500
+
+    Use if statements instead of switch for a few API's
+
+[33mcommit f6d1516068c33085766dfa042fe843f69511277c[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 17:26:19 2015 -0500
+
+    Sketch auto format
+
+[33mcommit 5e3605e67ef21d1b59fc5d3d7e7f034c674d6477[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 17:15:06 2015 -0500
+
+    Keyword updates from Helena
+
+[33mcommit ef3ccb5aebee42c2497631b8e7b77ecd5b5c2359[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 17:10:10 2015 -0500
+
+    Update example to use enums
+
+[33mcommit 0faeb636cda253ad2768af7db12df42b3c689aa0[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 17:09:13 2015 -0500
+
+    Add set/get gyro/accelerometer rate API's, and map more BMI160 enums
+
+[33mcommit 38f928fff483abfba10927610f889e022779f52a[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 16:33:34 2015 -0500
+
+    Use enums for accelerometer and gyro ranges
+
+[33mcommit e5a1c21005d0f6049008e8856481c4642b5227ef[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 15:34:39 2015 -0500
+
+    Example updates from Helena
+
+[33mcommit 0b57d5eea31457d9bef2bf4df76a8c1dcc0b92da[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 18 15:34:02 2015 -0500
+
+    Add Arduino style API's for IMU, rename CurieImu to CurieIMU
+
+[33mcommit b5c27aef2d78d264733f1056a070ca49de407f2e[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Dec 15 16:11:48 2015 -0800
+
+    ATLEDGE-429 CurieSoftwareSerial fixes
+    
+    -Creating a new CurieSoftwareSerial object no longer break functionality
+    of previous ones.
+    -Minor Cleanup
+
+[33mcommit f9d1d5c5c26d615f08775d9bffd8bd58b5fd75a1[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Thu Dec 17 15:58:56 2015 +0100
+
+    hardcode sketchUploader version
+    
+    while we solve the bug IDE-side, it is safe to revert using the hardcoded version number to handle the sketchUploader installation;
+    This solves a clash with outdeted Galileo/Edison core which tools are picked randomly (depending on json download order and java filesystem library internal ordering).
+
+[33mcommit 520f922f28c53d22be751dc0e8fe60e9466fb548[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Dec 15 14:59:42 2015 +0000
+
+    ATLEDGE-426/ATLEDGE-445 CurieImu missing functions
+    
+    * Removed CurieImu.getZeroShockDetected() & CurieImu.getZeroMotionDetected().
+    * Functions replaced with CurieImu.getIntShockStatus() & CurieImu.getIntZeroMotionStatus().
+    
+    * Implemented getStepDetectionMode().
+    * There was no means of verifying setStepDetectionMode().
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 4422bce4466f9350baeed33a2b36b97fdde5694b[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Dec 9 15:09:55 2015 -0800
+
+    AGM-157 Add support for _BV() macro
+    
+    Add support for _BV() macro
+
+[33mcommit 0c1ba8baef33e74383c0be797955baf386d5c4aa[m
+Merge: 44bc8db b3273bd
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon Dec 14 16:55:28 2015 -0800
+
+    Merge pull request #84 from sandeepmistry/rtc-api
+    
+    Rename CurieRTC to CurieTime and integrate some Processing/Time lib API's
+
+[33mcommit b3273bd9cec3f721e9958a768456965c3a7fe5b2[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 19:26:13 2015 -0500
+
+    Update name in keywords.txt
+
+[33mcommit d0c2800286ecf575fa900d9210d7473c9e68ba04[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 14:30:26 2015 -0500
+
+    Simplify SetTime example, use hard coded time
+
+[33mcommit e5072e27a530a68acda9fe84fb96abaf1f31faac[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 14:27:15 2015 -0500
+
+    Add API's to convert epoch time to date/time component
+
+[33mcommit 304c733e07f4306c89533d5a36bc714cb43683ba[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 14:03:13 2015 -0500
+
+    Rename CurieRTC to CurieTime
+
+[33mcommit 4d9c07eb44178b0afb185f247de561da87d8aa3d[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 12:06:45 2015 -0500
+
+    Make current count value and counter load registers volatile
+
+[33mcommit b872431e1df13cebb07cef8b2d85bc0906202462[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 11:48:01 2015 -0500
+
+    Parse date and time strings using Arduino string class instead of sscanf
+
+[33mcommit ed69e4f8c0f57db4c910b84d65d93d67e716766b[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 11:27:42 2015 -0500
+
+    Auto format
+
+[33mcommit 7bb2c23d0db4503d59cfeab00b7f12be8c8ff32c[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 11:06:09 2015 -0500
+
+    Change CurieRTC lib to have Processing style time API's based on the RTC value
+
+[33mcommit 23a1c3b18c45abf82fd9b13393497d83c4496056[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Dec 14 10:34:41 2015 -0500
+
+    Remove bundled time library
+
+[33mcommit 44bc8db8808ede092e85dcdb67c3f03b9f24c59f[m
+Author: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+Date:   Fri Dec 11 15:32:34 2015 -0800
+
+    Fixed comparison between uint32 and int32
+    
+    JIRA: ATLEDGE-457
+    
+    Servo.cpp warning
+
+[33mcommit 51c7f7d9145e11f834a4fae290c6693cb871e3fb[m
+Merge: e093df3 956aac4
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon Dec 7 14:17:16 2015 -0800
+
+    Merge pull request #81 from sandeepmistry/arduino-ble-peripheral-api
+    
+    Initial port of BLEPeripheral style API to CurieBle library
+
+[33mcommit e093df3e60fca0338fe23c46ed3e34bb078ef5df[m
+Merge: 39881ec f6c59c1
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon Dec 7 13:16:24 2015 -0800
+
+    Merge pull request #80 from sandeepmistry/imu
+    
+    CurieImu examples updates and keywords.txt
+
+[33mcommit 956aac4612d5b81da30de7c5621596fa3c8d2be1[m
+Author: tigoe <tom.igoe@gmail.com>
+Date:   Thu Dec 3 23:33:37 2015 -0500
+
+    Style changes to IMU examples
+    
+    Note: IMU Library API still needs to be standardized.
+
+[33mcommit 744e66ebb2de90cfbe48d9d3f3497c18f74efddc[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 12:43:53 2015 -0500
+
+    Shorten local name in examples
+
+[33mcommit 44cd7e505e59644a3fca7303b316293372580f9f[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 10:45:47 2015 -0500
+
+    Update note on local name
+
+[33mcommit b272315dfe91418c79ee6ce445144ca3178a2571[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 10:37:13 2015 -0500
+
+    Misc example updates
+
+[33mcommit 93ce2bb743a166a88e1cd9e52bfe1d24be005f83[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 10:23:43 2015 -0500
+
+    Correct case of include
+
+[33mcommit ccfaa837fd5810424474bf4a045ae17837fe4b1f[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 10:12:52 2015 -0500
+
+    Correct setDeviceName
+
+[33mcommit 3c848247e8be8dd1b9c9622ebb4cb09fc2e6379e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 09:27:17 2015 -0500
+
+    Remove AutomationIO example
+
+[33mcommit 3b8efcc191ecbea77096f116195667fde19d85e4[m
+Author: tigoe <tom.igoe@gmail.com>
+Date:   Thu Dec 3 22:24:01 2015 -0500
+
+    Style changes to BLE library examples
+
+[33mcommit a5c7f84f29a4f3c14594d50695f372702abec940[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 17:01:21 2015 -0500
+
+    Correct incorrect read permissions for non-writable characteristics
+
+[33mcommit c6924337ea3cb561a950cf0f08accf8696b6f59c[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:55:03 2015 -0500
+
+    Dynamically allocate characteristic and descriptor data buffers
+
+[33mcommit 040b63b1d23533774edf7cb46604740bbe92d2ff[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:54:28 2015 -0500
+
+    Set initial value of characteristics
+
+[33mcommit 479e8600a665ad21b3b6181997ce871b100c94f4[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:50:16 2015 -0500
+
+    Sent initial value of switch characteristic
+
+[33mcommit 6d6a0c6e5b681c6be61a110d0fe4309c5a38b2a7[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:47:18 2015 -0500
+
+    Set initial value of switch characateristic
+
+[33mcommit ce32c92177a01fd6be5688bf693050d225570ace[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:40:57 2015 -0500
+
+    Remove while(!Serial)
+
+[33mcommit b6eea7463bd84ec516f56f98f50fd0f424460060[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 16:31:11 2015 -0500
+
+    Use bool for public API's return types instead of BleStatus type
+
+[33mcommit 1596dc12e3ca099d483d52476c3c8378ad8d7c3a[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 15:47:57 2015 -0500
+
+    Change public API types to use non-stdint types
+    
+    as per https://www.arduino.cc/en/Reference/HomePage
+
+[33mcommit 026f4c044879ae294e3c41aa0fe5d16336feefdf[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 15:34:42 2015 -0500
+
+    Replace battery monitor example with new version
+
+[33mcommit 7767d3d6c42fb1c555ac68a5c9e687b33e6afbd8[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 15:31:15 2015 -0500
+
+    Rename Ble prefixes to BLE
+
+[33mcommit ee0ae446682773bbd8b240de2d03a0627096e87c[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 14:50:40 2015 -0500
+
+    Separate device name from advertised local name
+
+[33mcommit c23609225aee221ed7ad83429b186826b55baca7[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 14:34:20 2015 -0500
+
+    Don't advertise the device appearence
+
+[33mcommit 661fc89a9981932103c2a0cc96d46becd6177018[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 14:29:37 2015 -0500
+
+    Correct advertised service uuid
+
+[33mcommit fe78397481705f520627c860db257ad62a9c5d72[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 14:08:36 2015 -0500
+
+    Correct presentation format descriptor handling
+
+[33mcommit c1882ee3119a3754378ed7f085c6ab19f53843ab[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 12:54:37 2015 -0500
+
+    Add special handling for 0x2902 and 0x2904 descriptors
+
+[33mcommit 8ee6a0264c81f9534633234b9ff8e809c37abbe0[m
+Author: hbisby <h.bisby@arduino.cc>
+Date:   Thu Dec 3 17:56:19 2015 +0100
+
+    variable name changed from switchCharacteristic to ledCharacteristic
+
+[33mcommit e0139b68668f891b4ccd6ef166db67c20c172686[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 11:51:58 2015 -0500
+
+    Add delay(1) in poll
+
+[33mcommit 1b4f5134b152fc062c2f7d2d2aa29f1dfdcb1218[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:41:51 2015 -0500
+
+    keywords.txt updates
+
+[33mcommit 855737bc879868ea759c4eed46ec9420c886752a[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:41:33 2015 -0500
+
+    Change internals to use less private friends, add comments in header files, make var types more consistent
+
+[33mcommit 6c946eda6d1ccd4a610e91ab99babbe7924832ca[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:33:37 2015 -0500
+
+    User serial baud rate of 9600 for all examples
+
+[33mcommit df691a9ff790a9cf020878104dc138c9c0aeda66[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:28:29 2015 -0500
+
+    Rename with capital B
+
+[33mcommit f68199943d2c525cb3d6fdcbd0cfaf07427aa18b[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:21:48 2015 -0500
+
+    Correct UUID
+
+[33mcommit 90886c696057dfd2fb95edeb60502b82c96f8d48[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Thu Dec 3 10:06:52 2015 -0500
+
+    Correct include filename
+
+[33mcommit 03673b47fa1cc950734baffb9bb8313629c366f9[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Wed Dec 2 16:57:46 2015 -0500
+
+    Use dashed UUID in example
+
+[33mcommit 940374fa55bae556ac093bad2cf6a200529150f2[m
+Author: hbisby <h.bisby@arduino.cc>
+Date:   Wed Dec 2 15:44:59 2015 +0100
+
+    changed format of long UUIDs
+
+[33mcommit 3d3f973329d08a4f617da27e30f03abed12c4335[m
+Author: hbisby <h.bisby@arduino.cc>
+Date:   Wed Dec 2 15:26:01 2015 +0100
+
+    ported examples from BLEPeripheral buttonLED and callbackLED
+
+[33mcommit 2581cffca43521c85d5c0101cf3c57878397930e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Dec 1 17:29:47 2015 -0500
+
+    API Cleanup
+
+[33mcommit 03c82d3babe18a2fbae49abd49ec9f72cb9127a2[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Dec 1 16:03:57 2015 -0500
+
+    Add new LED example
+
+[33mcommit 6e5a9dee80787f90c47435901792c27c2b2687a1[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Dec 1 15:20:24 2015 -0500
+
+    Add written and subscribed API's to BleCharacteristic, pass central into BleCharacteristic even handers, remove BleAck event for now
+
+[33mcommit cd54545dc25a0a47cddbfc7722d24f626db12cb2[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Dec 1 10:47:07 2015 -0500
+
+    Update previousMillis in example
+
+[33mcommit 3d3f65f2135bef419ce82dcc06690f251419f258[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Tue Dec 1 10:31:12 2015 -0500
+
+    Reverse UUID conversion loop
+
+[33mcommit 4dfc0a4f68b7cf7c57f05d5ae6a6770b8e718509[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 17:52:10 2015 -0500
+
+    Experimental BatteryMonitor example sketch with new API
+
+[33mcommit 99ab222ec39c31e2c27ba8962f4022c499b341b6[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 17:49:47 2015 -0500
+
+    BleCharacteristic event handler API's
+
+[33mcommit d4efbb2cf9f86ece8804877b268f8ce00f40b736[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 17:20:28 2015 -0500
+
+    Make descriptor BleCharacteristic API's private
+
+[33mcommit 06a05c2a86886ee4deab539d76a23e85798b0449[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 15:49:12 2015 -0500
+
+    More keyword.txt updates
+
+[33mcommit e01b7bf4d56a771c3ff3d9db9b1d26de05160a5e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 15:48:30 2015 -0500
+
+    BlePeripheral event handler rename, and misc var name consistency
+
+[33mcommit 69697e3670a813cfb6a5912d35e80427012f7645[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 15:21:46 2015 -0500
+
+    Add typed characteristics
+
+[33mcommit be1fcea44f1b9266a88de7d97b341ca4125585fe[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 14:13:03 2015 -0500
+
+    Change return type of BleCentrall::address a C string, make getLocalAddress private for now
+
+[33mcommit 2fb56144f09631a97e73b86f3ffeae5289497f10[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 13:13:11 2015 -0500
+
+    Whitespace formatting
+
+[33mcommit a711fa2a7bc1cb0cbeaae4b179010b4c2e5ed326[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 13:12:57 2015 -0500
+
+    Allow BleCharacteristic::setValue to be called before begin
+
+[33mcommit b06df63df5e01de9a13ceddb74dad9fb15d3b821[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 12:24:52 2015 -0500
+
+    Introduce BleUuid, UUID's are now strings externally
+
+[33mcommit 67d47f330d4e8de2999a4c82f25eed2c3c4c4e45[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 11:38:22 2015 -0500
+
+    Change begin to return BleStatus
+
+[33mcommit a1d134b6e8fc2ba15b2df3a28244facb5d7d4bd9[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Mon Nov 30 11:00:33 2015 -0500
+
+    Add BleAttibute class and add new public addAttribute API
+    
+    Make addPrimaryService and getState API’s private. As well as,
+    BleService::addCharacteristic, BleService::addSecondaryService, and
+    BleCharacateristic::addDescriptor.
+
+[33mcommit e136ce82f377896cd8f442fe626682654cb9086b[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 17:24:26 2015 -0500
+
+    Expose characteristic properties instead of access and notify mode
+
+[33mcommit 6d101d6288c9bad8960c73fafa40f54692e55333[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 16:45:50 2015 -0500
+
+    Split up GAP event callback registration
+
+[33mcommit bf3d0bbe1886be69b0b9fedac2a3c73a0cac59e0[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 15:55:22 2015 -0500
+
+    More keywords
+
+[33mcommit dbdebdb84f982c1edd8e9088e7b3d71a8534b7aa[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 15:55:08 2015 -0500
+
+    Add BleCentral class, disconnect API, split out BleAddress
+
+[33mcommit 4e2a4d7d64669448ea4edcfbd10f6194041a6a9a[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 14:12:03 2015 -0500
+
+    Add setAdvertisedServiceUuid API, and remove param to advertise from addPrimaryService
+
+[33mcommit 2881aa5175d2e0120a4c25dbf8188a589709405d[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 14:11:11 2015 -0500
+
+    Add uuid method to BleService
+
+[33mcommit e7b71f54697a90f1b27e306817142a502cfd0690[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:47:49 2015 -0500
+
+    Rename set/getName to set/getLocalName
+
+[33mcommit ff11e027d85ae5fc312bb87509b65c0f87e62729[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:41:00 2015 -0500
+
+    Add poll API (no-op for now)
+
+[33mcommit 60f6c475aa6b0cd3fe6e366adebc2d9ae4924c7b[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:37:21 2015 -0500
+
+    Add begin and end API's
+
+[33mcommit 6d5aa275c531c4fb180256f86e5ede51158710f5[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:31:18 2015 -0500
+
+    Rename bleDevice variable to blePeripheral
+
+[33mcommit 08fd946c6d1632198f4f3bc40d21ac8bb425c70e[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:28:13 2015 -0500
+
+    Initial keywords.txt
+
+[33mcommit e8bdd87b7b0cf9ee3d993b2c5542f7593272c41b[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:28:01 2015 -0500
+
+    Rename BleDevice.* files to BlePeripheral.*
+
+[33mcommit 7eea01f3e26eda828208ee64068dde040b253e88[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Nov 27 13:22:31 2015 -0500
+
+    Add CurieBle.h for main lib header
+
+[33mcommit f6c59c14f95772fa3d6de4b8dfdc697cf8867b0d[m
+Author: Sandeep Mistry <s.mistry@arduino.cc>
+Date:   Fri Dec 4 11:53:02 2015 -0500
+
+    Change CurieImu and BMI160 to KEYWORD2
+
+[33mcommit 3642f44a88069e89cd644faabae8c72da78a2bfd[m
+Author: hbisby <h.bisby@arduino.cc>
+Date:   Fri Dec 4 17:40:59 2015 +0100
+
+    added defines and classes to keywords.txt
+
+[33mcommit d8618b23ede8b769ecfe8cafee0695c2eea60956[m
+Author: hbisby <h.bisby@arduino.cc>
+Date:   Fri Dec 4 17:02:10 2015 +0100
+
+    adding keywords.txt for CurieImu library
+
+[33mcommit 262fd1e2940498c00d9871a455de21be1c73785f[m
+Author: tigoe <tom.igoe@gmail.com>
+Date:   Thu Dec 3 23:33:37 2015 -0500
+
+    Style changes to IMU examples
+    
+    Note: IMU Library API still needs to be standardized.
+
+[33mcommit 39881ec83254758186e58c8e291b05ff09f6151e[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Dec 3 13:16:44 2015 -0800
+
+    ATLEDGE-393 Update SD library
+    
+    Rebase library from version 1.05 to 1.06
+    Fixes issue with passing String class object to SD.exists()
+
+[33mcommit bca4512908095a1c6f04a1c975849080861ff609[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Dec 2 11:01:11 2015 -0800
+
+    ATLEDGE-423 Export compiled binary
+    
+    Make changes to platform.txt to allow exporting compiled binary as a
+    .hex
+
+[33mcommit 3c833b2536b4616b38ef342289bb5efb440b6769[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Dec 1 11:52:57 2015 -0800
+
+    ATLEDGE-442 Fix some SoftwareSerial Rx limitations
+    
+    Fixed some limitations for Rx on SOC_GPIO pins.
+    Rx should now be functional on all pins except pin 13.
+
+[33mcommit 0b100b2d006add6692a76d1658ca04b317b640a6[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Nov 25 21:24:00 2015 -0800
+
+    Atledge-184 Minor improvements to SoftwareSerial library
+    
+    Minor improvements to SoftwareSerial library
+
+[33mcommit 7150436d89ca73fa7af68cd81c312203a7da4d4a[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Nov 25 19:14:24 2015 -0800
+
+    CurieRTC - SetTime example not setting RTC
+    
+    RTC not being set because the wrong call was being made should call
+    RTC.set(t) to set the hardware RTC instead of setTime(t).
+
+[33mcommit 25acb322cad8505f9564ca435b0e113bf5b5d9df[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Wed Nov 25 16:28:00 2015 -0800
+
+    Fixed typo in old IDE version error message
+
+[33mcommit fc55eedd7ce7fafbc5b0dd35c61ed12f22c0f26c[m
+Author: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+Date:   Tue Nov 24 17:03:18 2015 -0800
+
+    ATLEDGE-455 verbose/quiet selection for upload
+
+[33mcommit 4984085e655687db615b3a9675ee374fba8d6cad[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Wed Nov 25 16:37:28 2015 +0100
+
+    Add error message if using IDE 1.6.6
+
+[33mcommit 69a88721160920cbd77b26836fc97a0549f87db4[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Wed Nov 18 10:59:59 2015 +0100
+
+    Fix recipe.ar.pattern to avoid warning at startup
+
+[33mcommit a22ea571d1863e3869ec5e9f29936d00822b8dcb[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Nov 24 14:01:14 2015 -0800
+
+    ATLEDGE-444 Fix Library warnings for Arduino IDE 1.6.6
+    
+    Some libraries were missing the "category" field in library.properties
+    Minor fixes in some libraries for 1.6.6 compatibility
+
+[33mcommit 5c29db6c5b00b32d7f4d2379c3e89d9fdcc076d6[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Nov 24 10:30:05 2015 -0800
+
+    ATLEDGE-396 Fix behavior of analogWrite() on non PWM pins
+    
+    For all non PWM pins, the behavior of calling analogWrite() should be
+    logic 0 if the value is 127 or less. For values of 128 or above, the pin
+    should go to logic 1.
+
+[33mcommit 7afbd91dd8c0aa2b39fbe696c0dcb506e28fddd6[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Nov 23 18:09:53 2015 -0800
+
+    ATLEDGE-416 Fix some compile issues with Time.h
+    
+    Fix some issues with compiling Time.h by updating to version 1.50 of
+    Time library
+    Also removed some examples that will not compile for Arduino101
+
+[33mcommit c7b04f7d7915407f5194f42abf3dcfc691cd23d8[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Nov 23 16:07:16 2015 -0800
+
+    ATLEDGE-384 Remove Esplora specific examples
+    
+    Remove Esplora specific examples
+
+[33mcommit 2beea3e778b05e985ac7daacce86fb94847c054e[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Fri Nov 6 10:33:12 2015 -0800
+
+    Resolving KW issue with SoftwareSerial destructor
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit b30a275c7221b614071767772e72b98ce93b7ed2[m
+Merge: 78afaae 3759bcd
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Nov 5 11:05:04 2015 -0800
+
+    Merge pull request #62 from kevin306/testing
+    
+    Klocwork issues
+
+[33mcommit 3759bcd7fc648ae686de973af3df50f92e2dff9f[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Nov 5 17:39:14 2015 +0000
+
+    Fix Klocwork#2051,2060: Array may be outside index
+    
+    Change && to ||
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 5baa3fc6386781a784148fdf2b3fc65476416f05[m
+Merge: afcc4ef 344f90d
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Nov 5 12:45:34 2015 +0000
+
+    Merge branch 'testing' of github.com:kevin306/corelibs-arduino101 into testing
+    
+    Conflicts:
+            libraries/CurieBle/src/BleCharacteristic.cpp
+
+[33mcommit afcc4efd16a7c7b9d915913d641a76f0b448eb3d[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Nov 3 15:38:37 2015 +0000
+
+    Fix Klocwork#2051,2060: Array may be outside index
+    
+    * Added check to ensure _data_len is within index values.
+    
+    * Had to repeat the branch statement rather than move it because of memcpy.
+    
+    * Fixed bug introduced(c8ecd5f) in WString.h when "len" became protected.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 344f90d892d33c47f121cc374643c5e28b51bbdd[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Nov 3 15:38:37 2015 +0000
+
+    Fix Klocwork#2051,2060: Array may be outside index
+    
+    * Added check to ensure _data_len is within index values.
+    
+    * Had to repeat the branch statement rather than move it because of memcpy.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 78afaae4c7f189dc44ec83d19745dc4bb4e7f6ac[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Nov 2 10:48:45 2015 -0800
+
+    ATLEDGE-229 CurieRTC and Time Library
+    
+    Initial implementation of the CurieRTC library for the built-in RTC
+    Includes the Time library plus 3 new examples for the Arduino101
+
+[33mcommit cacac37db51b7212b92f3e90ff944006771860c4[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Thu Oct 29 22:28:12 2015 +0000
+
+    Fix Klocwork#137: Non-void function does not return value
+    
+    Change getTimeStampClks() implementation from assembly to C.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 8fa6bbaa920005ea42f738f305bcd4852c822a1b[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Oct 28 16:28:50 2015 -0700
+
+    ATLEDGE-184 SoftwareSerial Library
+    
+    Port of SoftwareSerial Library for Arduino101
+    Tx works up to 384000 bps
+    Rx works up to 57600 bps
+
+[33mcommit 2ae262a2a87d0d85032da3d975e7f1385a02ea75[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Oct 29 14:41:28 2015 +0000
+
+    Fix Klocwork#2051,2060: Array may be outside index
+    
+    * Added check to ensure _data_len is within index values.
+    
+    * Had to repeat the branch statement rather than move it because of memcpy.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 739c4007ba9c4b7a77d57628eb9ea31ab204d880[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:47:44 2015 +0000
+
+    Fix Klocwork#543,544: Buffer overflow/null pointer
+    
+    * Added a check to ensure array does not access index value of -1.
+    
+    * Added a check for this null pointer.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit dd4845e5d4f7dca461587d8bc0cc998598b060bc[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:44:45 2015 +0000
+
+    Fix Klocwork#2081,2082: Uninitialized variable.
+    
+    * using memset to initialize struct to zero.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 79744c4255d4c33d21b79bbc6f99922476ad3adf[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:40:38 2015 +0000
+
+    Fix Klocwork#79,80,81,82: Uninitialized Variable.
+    
+    * using memset to initialize struct to zero.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 79008fa1132cd1c9790c50a3f96232f54774a1dd[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:38:07 2015 +0000
+
+    Fix Klocwork#671: Infinite loop.
+    
+    * Added comment to verify requirement for infinite loop.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit cfe0a5df34a7f8b94724a9b99f02b5e62e42854b[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:33:00 2015 +0000
+
+    Fix Klocwork#105: Pointer returned may be null.
+    
+    * Added a check for this null pointer.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 5e71e700d4d1b66f9e68fc725653db9859660255[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:30:11 2015 +0000
+
+    Fix Klocwork#100: Infinite loop.
+    
+    * Added comment to verify requirement for infinite loop.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit db2995a78d772adb072ce743e77eece69a01d0d8[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:28:23 2015 +0000
+
+    Fix Klocwork#91: Infinite loop
+    
+    * Added comment to verify requirement for infinite loop.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 62395e48e858c433a88c20523481382e90be21a3[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 28 16:25:14 2015 +0000
+
+    Fix Klocwork#1093: Infinite loop.
+    
+    * Added comment to verify requirement for infinite loop.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit b3afd60a73d2fa8ead92ffa8e66a264e64bafd12[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Oct 28 14:19:45 2015 +0000
+
+    Fix Klocwork#137: Non-void function does not return value
+    
+    Move getTimeStampClks() function to an *.S file
+    It is fully implemented in assembly and we take care of returning value by
+    filling in the proper value in the proper registers.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 0e094210f3d645b109adceb393a00b0b41acdf80[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Thu Oct 29 09:54:33 2015 +0100
+
+    fix BLE library String handling
+    
+    the correct way to get a String lenght is by calling String.length()
+    now len field is protected so a compilation error will be triggered
+
+[33mcommit 0ffb9749afb8dc53abd628e00ced6af07d0c97d1[m
+Merge: b17f321 6f35dfd
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Wed Oct 28 17:03:31 2015 -0700
+
+    Merge pull request #58 from facchinm/new_delete
+    
+    Fixes to pass validation with test suite
+
+[33mcommit 6f35dfd332c30b135c14d1f718f923299d7e6695[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Wed Oct 28 12:53:47 2015 +0100
+
+    stdlib_noniso: expand all functions up to base 36
+    
+    needed to pass a very strict test
+    Porting of latest Due implementation
+
+[33mcommit f07a20aa02e5421b1fc6e9775fdeb2221c8bd2a7[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Wed Oct 28 12:50:35 2015 +0100
+
+    remove misleading SERIAL_PORT_USBVIRTUAL define
+    
+    the Serial via USB port is not a real virtual cdc port (it still emulates an Hardware Serial), remove to avoid sketches getting confused and expect CDC flow control functions
+
+[33mcommit c8ecd5f0af6c87fdd02382f0cab275d83da31f2c[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Oct 27 18:01:17 2015 +0100
+
+    Sync IPAddress and Wstring with SAM implementation
+    
+    Test suite failed on these functions
+
+[33mcommit d179695b0494b96cc1feb963905ee8fea9a7d2a5[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Oct 27 15:41:24 2015 +0100
+
+    Add new/delete implementations
+    
+    This is needed to pass C++ validation in test suite
+
+[33mcommit b17f321e32464222ff433afa69af2ba3fe0149c5[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Oct 27 15:40:30 2015 +0100
+
+    Specify architecture in library properties
+    
+    to avoid conflicts with standard libs
+
+[33mcommit cd4f66d4620a8aabb4bfb966fe6564a367a24f32[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Oct 22 17:50:32 2015 +0100
+
+    libarc32drv_edu.a: Update of pre-compiled driver library.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 95174ce3dd682621e1f74ef0e04e818b0ff1dce3[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Oct 22 17:47:07 2015 +0100
+
+    build: unused global variables in header file causing BLE build failure
+    
+    factory_data.h defines 2 global variables which aren't actually used anywhere.
+    However, they become global symbols in any C files that include this header
+    file.  For most builds, this header file is included only once but, for CurieBle
+    library builds, it is included by another C file as well.  This causes a linker
+    error due to duplicate symbols in the final image.
+    
+    The simple solution is to just remove these variables, because they aren't used.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 7052d8fe88034c92bd845b818bd1c028adea0444[m
+Merge: 6efbac6 c5e9152
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Oct 14 16:20:32 2015 -0600
+
+    Merge pull request #52 from 01org/arduino101-rename
+    
+    ATLEDGE-364 Rename EDU to Arduino 101
+
+[33mcommit c5e915295c995aebc15ecab2a2538b6c3ab20f23[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Oct 14 15:14:56 2015 -0700
+
+    ATLEDGE-364 Rename arduino_101_x to arduino_101
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 570a904927ca18737613dbee8f4640382dba0746[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Oct 14 14:56:03 2015 -0700
+
+    Update pre-compiled library
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit d342223adc0676d5c39a0d89f9ab94d0cea5e56e[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Wed Oct 14 14:55:55 2015 -0700
+
+    ATLEDGE-364 Remove CONFIG_BOARD_ATLASPEAK_EMU specific code
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 6efbac63436af6e286aa4b5e09b30bbe4cebeb80[m
+Author: Manoel Ramon <manoel.c.ramon@intel.com>
+Date:   Tue Oct 13 15:49:41 2015 -0700
+
+    ATLEDGE-316 - isAlphaNumeric returns incorrect bool for '@'
+
+[33mcommit 31e75615c26a6d19c168fc16e6b44d4e9504c45b[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Oct 14 12:11:13 2015 +0100
+
+    Missing examples folder in Wire library
+    
+    - Slave examples not relevant because AtlasPeak does not support
+      slave-mode I2C.
+    
+    - Examples included  digital_potentiometer, master_reader,
+      master_writer, SFRRanger_reader.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 4c04540989a546fb6b668f35cee49a272bed9019[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Oct 13 16:01:50 2015 -0700
+
+    ATLEDGE-364 Rename EDU library folders
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit d7617aba523a269a0d8278ba758bbe706fdd74f3[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Tue Oct 13 15:56:24 2015 -0700
+
+    ATLEDGE-364 Rename EDU to Arduino 101
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 7436867a37228a6bdeecf87c80489187a99f01ed[m
+Author: Manoel Ramon <manoel.c.ramon@intel.com>
+Date:   Wed Oct 7 22:10:55 2015 -0700
+
+    ATLEDGE-358 - BLE Broadcast name must read the product name in the OTP
+
+[33mcommit 94ea92298feee063539ed2ca791cdef826d71333[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Oct 13 14:42:51 2015 +0100
+
+    Updated libarc32
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 5a1c28cd384e01c50068aca8c7b379b05bb50571[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Oct 13 14:36:32 2015 +0100
+
+    ATLEDGE 201 Pointer returned may be null
+    
+    Added a check for this null pointer.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 45e6046f09e2c465c69456869cee6992792e4f55[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Oct 13 13:04:04 2015 +0100
+
+    Files no longer in use, can be removed.
+
+[33mcommit 15dbf74d82907eb0af47ad9c5ef682fa298b11f3[m
+Merge: 685eed6 aa8e01a
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Mon Oct 12 11:43:12 2015 -0700
+
+    Merge pull request #48 from Dan-Emutex/adafruit_libraries
+    
+    Adafruit libraries
+
+[33mcommit 685eed663cedc37c91855048c216872a479605ad[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 9 16:49:22 2015 +0100
+
+    imu: revert commit b62bbfc89b
+    
+    This commit essentially reverts the changes made in b62bbfc89b.
+    That is, it removes some Accelerometer data sampling rates which
+    we don't support in the mode that we are using the Accelerometer
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit aa8e01a64fe31172758ee0b1c66b4a3ce521730b[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 17:59:40 2015 +0100
+
+    dotstar: initial port to AtlasEdge
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 4fee1cca6bac948cb010cadb6b9fba33d8fbc2c6[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 17:57:02 2015 +0100
+
+    dotstar: add DotStar library v1.0.1 from Adafruit
+    
+    - Adafruit_Dotstar Github repository: https://github.com/adafruit/Adafruit_DotStar
+      Tag: v1.0.1
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 6e2de131cbfd585cf027f41353a71707185a8bbd[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 17:52:45 2015 +0100
+
+    motorshield: initial port to AtlasEdge
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit e671f3f6c3b134d6b326c671de255c2f47d83969[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 17:07:56 2015 +0100
+
+    motorshield: add Motor Shield V2 library v1.0.1 from Adafruit
+    
+    - Adafruit_Motor_Shield_V2_Library Github repository: https://github.com/adafruit/Adafruit_Motor_Shield_V2_Library
+      Tag: v1.0.1
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 146b0bf2912cf09735f2701564261bb06d2aa6b3[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Mon Sep 28 17:00:30 2015 +0100
+
+    neopixels: initial port to AtlasEdge
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit ca4d7f2530f4077d6d1108d450c32afaa9f7862a[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Mon Sep 28 14:18:41 2015 +0100
+
+    neopixel: add Neopixel library v1.0.3 from Adafruit
+    
+    - Adafruit_Neopixel Github repository: https://github.com/adafruit/Adafruit_NeoPixel
+      Tag: v1.0.3
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 7d930a50dbfb0890b4bb0915fe34c5dc2bdd6d79[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 9 13:21:22 2015 +0100
+
+    imu: fixed and simplified (set|get)ZeroMotionDetectionDuration methods
+    
+    Validation feedback revealed logic errors in
+    setZeroMotionDetectionDuration and a lack of clarity on how it should
+    be used.  Addressed by providing an explicit set of valid values for
+    the user to pass to the method, which can in turn be written directly
+    to the relevant register
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 7134c41e2940db726cfa293f19e9207cc9b643a2[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Mon Oct 5 10:17:29 2015 +0100
+
+    imu: improve interrupt-safety of CurieImu API methods
+    
+    Ensure that SPI transfers cannot be interrupted, and
+    avoid use of global buffer to improve interrupt safety
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 252bd5308f34dd442d9190d36bfbe7f7b1379402[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Mon Oct 5 15:26:15 2015 -0700
+
+    Updated libarc32
+
+[33mcommit b1cbef53bbd79333c0df25816078a7eab4b441bc[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 15:26:25 2015 +0100
+
+    imu: minor tidy-up of documentation for API enumeration values
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit b62bbfc89bc35b3a0a04de74f7e4898371922a83[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 14:31:57 2015 +0100
+
+    imu: add missing accelerometer sample rate options
+    
+    - The following sample rates were previously omitted:
+      - 25/32 Hz
+      - 25/16 Hz
+      - 25/8 Hz
+      - 25/4 Hz
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 426367514593a075b3dc5d373dca10e82cf24112[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 14:28:22 2015 +0100
+
+    imu: remove invalid 3200Hz accelerometer sample rate option
+    
+    The maximum sample rate for the accelerometer is 1600Hz
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit c8c4d98b50644141b77868996e226fba167944c9[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 14:06:00 2015 +0100
+
+    imu: fixes/improvements needed for TapDetect example
+    
+    - Threshold was set incorrectly, leading to over-sensitive detection
+    - Default accelerometer range of 2g prevented detection of strong taps
+    - Added comments to explain the code in more detail
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 23bd20fe1081edde07fca0a85718f5a52987abfc[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 13:49:24 2015 +0100
+
+    imu: compile error in RawImuDataSerial.ino when CALIBRATE_ACCELGRYO_OFFSETS defined
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 67629a6de0e9163f1a7631fa2ae28c9f5b9e4765[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 13:34:48 2015 +0100
+
+    imu: remove delay between bi-dir SPI transfers causing data loss
+    
+    A wait for TX to complete, followed then by RX, was causing data
+    loss due to the fact that it was waiting for the busy status flag
+    to clear after TX, but this doesn't clear until after RX is also
+    complete.  The result was data loss due to RX FIFO overflow.
+    Fixed by disabling the wait between TX and RX steps.
+    
+    This affected functions requesting more than 8 bytes from the
+    BMI160, such as getMotion6() and getFIFOBytes() methods.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 599e33bf4bfd604f68e55252511075e078c673de[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Oct 1 12:55:05 2015 +0100
+
+    imu: fixed error in reg_write_bits
+    
+    - reg_write_bits was erroneously clearing all other bits in
+      a register outside of the bits targeted for the write
+      operation.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 17b8d04c60919d25ccac54d7cf2901c1d0f0e285[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Mon Sep 28 14:08:28 2015 +0100
+
+    imu: minor clean-ups
+    
+    - removed some dead code
+    - added/corrected some code comments
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit e4904009052717894720323d8b037307b24b9204[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Sep 25 18:10:25 2015 +0100
+
+    imu: adding support for tap detection by BMI160 accelerometer
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit a5a12fc002430d002d9434f47582577da5c36631[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Sep 25 15:21:05 2015 +0100
+
+    imu: added support for Step Detection/Counting in CurieImu library
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit b759ec35f46ef38d77fcd90ad1d91a5840607aaa[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Sep 25 01:36:11 2015 +0100
+
+    imu: fixes for issues found while testing shock detection
+    
+    - Created new SPI driver using polling instead of interrupts.
+      This allows it to be used within an ISR so that
+      we can check the source of the CurieImu interrupts.
+    - Fixed bit manipulation logic for partial register read/writes
+    - Added a new example sketch to demonstrate Shock Detection function
+    - Fixed IMU power-up logic
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 982a470e6909bd444a399b49ced4749d9da72754[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Sep 17 15:59:50 2015 +0100
+
+    Initial commit for new CurieImu Gyro/Accel library
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit e25bcde0d0b7f9fc635e376aa649884a369d6c45[m
+Merge: 6f196e1 2b11283
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Fri Oct 2 12:32:31 2015 -0600
+
+    Merge pull request #46 from 01org/cdc-acm
+    
+    CDC-ACM: move allocation of shared buffers to LMT - Has pair commit in Thunderdome
+
+[33mcommit 2b112833285765ef1e9436d5a82f1eeb65f53df8[m
+Author: Calvin Sangbin Park <calvin.s.park@intel.com>
+Date:   Fri Oct 2 10:32:51 2015 -0700
+
+    Updated libarc
+
+[33mcommit 05d4ecade9f44e2d86a43fde1030b2b0167236ed[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Oct 2 16:02:09 2015 +0100
+
+    CDC-ACM: avoid race condition.
+    
+    * In case bool() is called in a very tight while loop, give LMT space
+      to set the host_open shared variable.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit b8d9b11d8d1c61d704f967d5d730b244c72d918f[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Oct 2 12:19:29 2015 +0100
+
+    CDC-ACM: change end and init to avoid race condition.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 5174c9c7e1634eef20c84b436c58a7b7cbbddbb3[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Oct 2 10:29:43 2015 +0100
+
+    libarc32drv_edu.a: Update of pre-compiled driver library.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit a6473d1fc4c8e4207f974eac273b0f5781341bc7[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Oct 2 00:11:03 2015 +0100
+
+    CDC-ACM: move allocation of cdc-acm shared buffers to LMT
+    
+    LMT shall now be responsible for allocating shared data buffers
+    used to exchange CDC-ACM data between ARC and LMT.
+    
+    Defined a revised set of structures to allow the pointers to
+    be passed from LMT to ARC during initialisation.
+    
+    NOTE THAT THIS DEPENDS ON A CORRESPONDING CHANGE IN THUNDERDOME
+    FIRMWARE
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 6f196e1fcdb422ca29229af27ff984eb113e3bd0[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Oct 1 22:11:13 2015 -0700
+
+    Updated libarc32
+
+[33mcommit 4f1a71a77685e4b98a2c0345773bb5c92cbc98f4[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Sep 11 08:59:45 2015 +0100
+
+    CDC-ACM fix flush() API
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 0f07ea0e5dcf0039761e256a7efe7f327270124e[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Sep 10 13:43:13 2015 +0100
+
+    CDC-ACM - Fix slow write() performance and availableForWrite() logic
+    
+    - Removed delay in write() function which caused slow TX performance
+    - Removed timeout logic in write() function; moved to LMT side
+    - Fixed logic in availableForWrite() - ring-buffer capacity is at most
+      1 less than actual size to avoid head index passing tail index
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 33f4380d60a5f3fd110965f15565f3b83b57d6c9[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Sep 8 10:57:00 2015 +0100
+
+    CDC-ACM - address review comments.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit ddb0003c675d648f1b49ea8956e5b0f3b49d4775[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Mon Sep 7 15:36:58 2015 +0100
+
+    CDC-ACM using shared memory buffers
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 6d0fc98091cedcc6c2e947878bdf7f5201592abe[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Sat Sep 19 09:50:03 2015 +0100
+
+    ble: update libarc32drv_edu.a
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 9314b22ff29e70c400c61d8f39c6486d8faa03ad[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Sat Sep 19 09:41:46 2015 +0100
+
+    ble: address code review comments from Manoel Ramon
+    
+    - Added checks in example sketches for API return values
+    - Applying Public MAC address if present in factory data
+    - Applying default device name if user doesn't provide one
+    - Only issuing notifications/indications if enabled by peer
+    - Re-sync'd with latest BLE code from Thunderdome
+    - Added basic DTM support for use in sketch (for internal testing)
+    - Other minor updates, corrections and clarifications
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit a709e252eb60dec7eb7f923797814e72ffda5dcc[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Fri Sep 18 09:47:10 2015 -0600
+
+    ATLEDGE-334 Update version header location in linker script
+    
+    Need to update linker script to match recent firmware change:
+    
+    JIRA: FIRE-2160
+    
+    1024 bytes were used to store the version header, which is only
+    48 bytes big. So we wasted 976 bytes. By moving it after the vector table,
+    we can free this 1024 bytes space.
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit c33d42adca3d1fd4295e7df8f278c41089da26f6[m
+Author: Brian Baltz <brian.a.baltz@intel.com>
+Date:   Thu Sep 17 12:58:44 2015 -0700
+
+    ATLEDGE-333 CLUploader script path is hard-coded
+    
+    Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>
+
+[33mcommit 28304b5b8ba763fe00d23cd074f23b3b8e6b97e0[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Wed Sep 16 17:51:36 2015 +0100
+
+    uart: fixing baud divisor calculation to add support for 230400 bps
+    
+    Added code to configure the UART fractional divisor to improve the
+    UART timing at higher speeds such as 230400, 460800 and 921600 bps.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit b96562dbb3c63d5cc894f128d61de4f1bc6de3d5[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Wed Sep 16 14:45:05 2015 +0100
+
+    wire: adding support for I2C RESTART and some minor clean-ups
+    
+    - Added support for sending repeated-START conditions on the I2C bus
+      By adding an option to not send a STOP condition at the end of a
+      transfer, it is possible for the I2C master to hold the bus and
+      send additional transfers.  If switching from writing to reading,
+      or vice-versa, the I2C master controller will automatically send
+      a repeated-START (RESTART) in between.  For consecutive writes or
+      consecutive reads to the same slave, a repeated-START is not needed.
+    
+    - Cleaned up some redundant code and removed some unsupported methods
+      in the Wire library implementation for AtlasEdge, particularly those
+      related to I2C Slave-mode.  AtlasEdge supports I2C Master-mode only.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 026afb2d00b89999b07bd7c5c6bc54cd29bbb310[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Sep 14 16:11:37 2015 -0700
+
+    ATLEDGE-231 TFT Library
+    
+    Add missing wiring_private.h file
+
+[33mcommit 6b5577e058a46fcfca5ba91ccd3c9824acd941b6[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Sat Sep 12 11:26:50 2015 +0100
+
+    ble: adding new CurieBle Arduino library for AtlasEdge
+    
+    Added new BLE library and examples, providing access to
+    basic GAP/GATTS features of Intel Curie module
+    
+    Includes a port of the BLE Core Service CFW API and
+    UART-IPC drivers from Thunderdome code base
+    
+    Also includes a shift of CFW master role from LMT to ARC.
+    Requires matching commit 4d056720 or newer in thunderdome
+    atlaspeak_atlasedge project source tree to work correctly
+    
+    Known issues:
+    - A fix in Nordic BLE firmware is required to support
+      adding Presentation Format descriptors to characteristics.
+      Until that fix is available, the addPresentationMethod()
+      of the BleCharacteristic class should not be used.
+    - Due to issues with the current CDC-ACM implementation on
+      AtlasEdge platforms, use of Serial should be replaced with
+      Serial1 in the CurieBle example sketches, until CDC-ACM
+      issues are resolved.
+    
+    Not currently supported:
+    - Direct Test Mode (DTM)
+    - Bluetooth bonding (pairing)
+    - BLE Central Device role and GATT client functionality
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 4cf249987b5da85a90025d174021824e5ce09cc6[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Mon Aug 17 22:49:26 2015 +0100
+
+    Port OneWire to Atlas Edge board
+    
+    * Implement platform specific macros for Intel AtlasPeak SoC.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 42da7aadcf2439bb4adaa5a1e112381786639486[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jul 31 16:23:55 2015 +0100
+
+    Add Paul Stoffregen's OneWire library version 2.3
+    
+    * 1-Wire Github repository: https://github.com/PaulStoffregen/OneWire
+      tag: 2.3
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit d439d3be7522a5d4c2adf552039b089dea0d495f[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Sep 10 11:13:58 2015 -0700
+
+    ATLEDGE-231 TFT Library
+    
+    Add AtlasEdge support to TFT library
+
+[33mcommit f34bda4517f1cc199d29e3fe51c220cae5b2cf4c[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Wed Sep 2 12:53:49 2015 +0100
+
+    Updated license headers in Thunderdome-derived source files
+    
+    New license headers and other minor changes have been imported
+    from the Thunderdome code base.  Note that no functionality has
+    been added/changed/removed in this commit.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 647e20823be90638e707fbcb66c8be4e1f9ea351[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Aug 25 10:24:03 2015 -0700
+
+    ATLEDGE-279 F_CPU not defined
+    
+    Added F_CPU to boards.txt and platform.txt.
+    Fixed format of boards.txt
+
+[33mcommit d3bbf49643a9fdd2a19426f5818cd602e1e99e8d[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Mon Aug 24 16:34:21 2015 -0700
+
+    ATLEDGE-228 SD Library
+    
+    Add AtlasEdge support to SD library
+
+[33mcommit 83a4c0213a24c32e4f2924fbbcad5dd5afca9ec3[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Aug 21 13:05:14 2015 -0700
+
+    ATLEDGE-272 SPI broken by new clock gating feature
+    
+    Enable clock gate before configuring SPI
+
+[33mcommit c29233c5826e85f49173a77757400678471bd49b[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Aug 12 12:40:28 2015 +0100
+
+    Cleaned up buffer handling in CDCSerial class.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit b9d35bdac7c27a1c407fe2e0d4f97236a980f312[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Aug 6 14:28:16 2015 +0100
+
+    libarc32drv_edu.a: Update of pre-compiled driver library.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 7fa713d2ef47140a82b4b0f50ab31ec43206fada[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Aug 11 13:53:48 2015 +0100
+
+    Address review commments on cdc-acm serial
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 511a8d76f20698813cafa1b0f7130e40f37cdaea[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Aug 4 12:23:24 2015 +0100
+
+    Changes out of code reviews.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit d85aa9643ac15389004d05217e67d438d689916d[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Jul 29 14:45:44 2015 +0100
+
+    Added CDC-ACM serial functionality as Serial.
+    
+    Pin header pins 0 and 1 have moved to Serial1
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 347ded518d9731dd93460b569168f2631ad604c1[m
+Author: Manoel Ramon <manoel.c.ramon@intel.com>
+Date:   Thu Aug 13 16:28:39 2015 -0700
+
+    ATLEDGE-44 Creation of platform ID and platform name for Atlas Edge
+
+[33mcommit a9c0430563473d556a766ac7df953969363f3bc8[m
+Author: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+Date:   Tue Aug 11 18:33:04 2015 -0700
+
+    vid/pid change
+    
+    JIRA: ATLEDGE-181
+    
+    Signed-off-by: Krzysztof Sywula <krzysztof.m.sywula@intel.com>
+
+[33mcommit 7d55eb88f2c659ca0dc3bc83ef607fbeb439bbe2[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Tue Aug 11 10:48:22 2015 -0700
+
+    ATLEDGE-141 Add ATN pin as a regular gpio
+    
+    Added ATN pin as a regular gpio as pin 20
+
+[33mcommit e487817583d12c6ef1203ef60c14cd4882509b32[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Aug 11 13:56:19 2015 +0200
+
+    import stdlib noniso functions
+    
+    try not to reinvent the wheel
+    solves print(*, BIN) returning "unsupported base"
+
+[33mcommit a03d93d5634335a96549c1c41923e03424f5d488[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Aug 11 12:34:10 2015 +0200
+
+    add support for String operation with uint64_t
+    
+    fixes examples StringConstructors, StringAdditionOperator, StringAppendOperator
+    
+    only needed because millis() returns a uint64_t
+
+[33mcommit 2dbdd016cc9cf47649c55141b56bc7c2e64315ad[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Aug 6 15:38:23 2015 -0700
+
+    ATLEDGE-30 Port Ethernet Library
+    
+    Port of the Ethernet Library for Atlasedge.
+    Added missing files from cores directory needed by Ethernet, WiFI, and
+    other similar libraries.
+    Works for Arduino 1.6.5 and above
+
+[33mcommit 293b27908134ab79d689020dece0bf6ce8cc02a7[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Thu Aug 6 15:04:43 2015 +0100
+
+    Fix the build.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit bc74b7df42ec1a9413dd044b814363c7cc51bdeb[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Thu Aug 6 13:48:37 2015 +0100
+
+    Address code review comments
+    
+    * Correct spelling error evry => every
+    * Remove magic number 0xFFFFFFFF and define it as FREE_RUN_TIMER
+    * Remove 2 and 10 magic numbers from Print class; use BIN and DEC instead
+    * Add base checking inside printNumber() and printLongLong() methods
+    * Remove some unnecessary white spaces.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 3cc79807014c1f386e12017c4063ccc62db9e15c[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Aug 4 12:21:44 2015 +0100
+
+    ATLEDGE-185 - String object is missing functions
+    
+    Also included Bug #2289 overloaded operators missing
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit e3f227ff6fe7c5530a2f99f2c42206dd08071020[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Mon Aug 10 15:05:26 2015 +0200
+
+    WStrings: add c_str function
+    
+    this fixes SD library compilation
+    
+    However, in the long term, WString, Print, IPAddress, Stream and WMath (every core file non hardware-related) should be aligned to AVR version to avoid incompatibilities with derived classes
+
+[33mcommit fd8b3e5e6899ed12ada55829c7557be0402dd123[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Mon Aug 10 14:53:57 2015 +0200
+
+    Add digitalPinTo* macros/functions
+    
+    these functions ensure compatibility with lots of existing libraries
+
+[33mcommit f3f2b0bc66b053b2cd59cee578906a2f7d83eabc[m
+Author: Martino Facchin <m.facchin@arduino.cc>
+Date:   Tue Jul 21 18:09:38 2015 +0200
+
+    Improve Wire library
+    
+    still unreliable though
+
+[33mcommit a33835c16343c18ed75e51418ff02c72684a745b[m
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jul 31 13:56:57 2015 +0100
+
+    ATLEDGE-177-char-Signed
+    
+    Char is now signed (fix of previous regression in merge)
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 0aa51368ea4b1688aecbe2b2b0b8b1bf57058ecf[m
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jul 31 12:50:14 2015 +0100
+
+    libarc32drv_edu.a: Update of pre-compiled driver library.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 31513f70d52408093dfbcaeeee4ec77e9c1c3dcb[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Jul 29 17:37:35 2015 +0100
+
+    Fix bug #2220: delay(150secs) only waits for approx 15secs
+    
+    Root cause:
+     While transforming milliseconds in clocks, the result of an uint32_t
+     multiplication overflows
+    Solution:
+     Cast one of the operands to uint64_t
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit b365f143e2b11346ee54a9c48f6c6b3b48e33e56[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jul 29 11:14:02 2015 +0100
+
+    Bug#2262 String Object compile error
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit da0eaa49fe58a431fdf03403355cf71ab671b9bd[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jul 29 14:06:08 2015 +0100
+
+    ATLEDGE-209 tone() bug when frequency = 0
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit bc7fbd8adbf3058f4dc3bae0c9a1568b3e98ba3f[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jul 30 11:32:26 2015 +0100
+
+    Bug# 2265 - fixed parseInt(skipchar) Compilation error
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 67e7f2e9843096b03110cefdc5e702d896bf5be6[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Jul 29 10:07:37 2015 +0100
+
+    Added support for printing long long values, e.g. millis()
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit abe68dea6befe32fc4ce2951c5bb2e89c2e4bd45[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Jul 29 12:14:56 2015 +0100
+
+    ARC init: enable FIRQ
+    
+    * Change interrupts priority from 1 to 0 (FIRQ)
+    * Modify linker script: add stack area for FIRQ
+      Define a stack memory section in SRAM and split it between run time
+      and FIRQ stacks.
+    * Replace existing generic ISR; it initialises the SP, decodes the IRQ
+     source and finally jumps and links to the specific ISR.
+    * Modify _IsrTableEntry structure: get rid of ISR parameter.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 47fab774f96532134ad74a8c16bcecf6c9fdefbf[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Mon Jul 27 14:37:09 2015 +0100
+
+    ATLEDGE-169: Change interrupt routing mask
+    
+    Issue: The LMT receives an interrupt enabled by SS because the routing
+           mask is disabled for both cores (the interrupt is routed to both
+           ARC and LMT) and it masks it because it is a "spurious irq" from
+           its point of view.
+    
+    Fix: When the ARC enables an interrupt source, it configures the interrupt
+         router to route the interrupt only to ARC core.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit ab97250c0df109b68f71983fe0046b2d16f839fc[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Jul 28 11:58:41 2015 +0100
+
+    Bug #2184 Serial.begin() config not implemented
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit e542703d8458e5769ab6d8aa38a9a565aaff83a3[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Fri Jul 24 12:43:34 2015 +0100
+
+    ATLEDGE-177-char-Signed
+    
+    Char is now signed
+    Boolean modified to be a bool not an int
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit afcd5f7932f62f7692121b9dcce8b67972a2fac6[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Jul 16 15:45:30 2015 +0100
+
+    Enable/disable_internal-pullup_with-digitalWrite
+    
+    Emulate Arduino pull-up control, by allowing a digitalWrite() on an INPUT pin to toggle the internal pull-up
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 925ddb77900e4bb8ede5f59daf7656073c81bb2b[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Wed Jul 29 15:01:15 2015 -0700
+
+    ATLEDGE-224 port avr/pgmspace.h
+    
+    many libraries fail to compile because they need avr/pgmspace.h.
+    Galileo/Edison had the same issue and the same code can be ported over.
+
+[33mcommit 6875a7ffed5d9dd038037148efccc0ef1fe2f2f6[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jul 15 09:26:12 2015 +0100
+
+    Bug fix to allow three methods for Serial.Write()
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit a50e097c7c7d217b4d0b9135a9d2e970f435edcf[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Jul 14 23:05:16 2015 +0100
+
+    Arduino core functions: pulseIn
+    
+    Change pulseIn implementation to be inline with the new time functions
+    which provide 64 bit timestamps.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 895d7b94b167cafbd6306ce79942c7f2bc811181[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Wed Jul 15 14:17:35 2015 +0100
+
+    Temporary fix is to compile with -O0 instead (optimisation disabled).
+    Further investigation required.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 9bf75da8684e5917d343795eb9f1156d28eb89b4[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Jul 15 12:24:01 2015 +0100
+
+    libarc32drv_edu.a: Update of pre-compiled driver library.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 33342070baf9a8b5dadc26d9691499d30461be68[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Jul 14 20:59:11 2015 +0100
+
+    Time related Arduino core functions: Re-write
+    
+    * Change Timer0 configuration according to Alexandre D'Alton suggestion:
+      use it as a free-run timer which delivers interrupts every 0xFFFFFFFF
+      clock ticks and its ISR increments a global variable; in this way a
+      64-bit virtual RTC is created. The downside is the delay() function
+      cannot take advantage of ARc's power management features anymore.
+    
+    * Change delay() implementation to make use of 64-bit time-stamp.
+    
+    * Change delayMicroseconds to use Timer0 counter value and unsigned
+      arithmetic's features to handle the overflow case.
+      The credit goes to Dan O'Dononvan.
+    
+    * Add function to get an atomic 64-bit time-stamp.
+    
+    * Change millis() and micros() implementation to use the 64-bit time-stamp.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 7405797b110db61e838dc92141f7d8082b159c3a[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri Jul 10 09:45:36 2015 +0100
+
+    Updates and fixes to Component Framework code for Arduino on ARC
+    
+    - Sync'd CFW code with Thunderdome code base from 01-July-2015
+    - Fixed issue with mailbox interrupts halting CPU, caused by bug in scss_registers.h
+    - Added CFW test service client to facilitate CFW sanity check (requires LMT build running Test service)
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit cdc73f8e532be8ea3c5791fe575bc30381a6e0dc[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jul 9 14:29:46 2015 +0100
+
+    Fixed redmine 2150 - inByte variable declaration issue
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 4489870248153835baa05bcc6956f0f0f81ffb37[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jul 9 16:03:43 2015 +0100
+
+    Remove unneeded main.c from driver library.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit ecbe76a8febfd31a8b0f1d3dd30fa6545bafafec[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jul 9 14:01:45 2015 +0100
+
+    Fixed macro for enabling pullups, plus fixed pin# for IO8
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 3193ffc31ab65125c66337aadef85c6da3d22d2b[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jul 10 15:52:33 2015 +0100
+
+    Update of pre-compiled driver library.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit c968b172d1b0ca86936ae34793d701ac2fee778f[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Jul 8 17:31:48 2015 +0100
+
+    Reduced footprint of blink sketch from 65K to 25K by removing call to sprintf
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 4fc372ef78d1929fc1ff12d1c1a806c1dc236bdd[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jul 8 15:31:45 2015 +0100
+
+    Remove hardware loop-back flag set in SPI.begin()
+    
+    This was added previously for internal testing, but was not fully removed prior to release
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit f88353e642f8e88361a055fdecdf8fef3f41e337[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Jul 8 13:54:26 2015 +0100
+
+    Fix for malloc(), round up to 4k Pages.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 13cd850d73127de56c31945a3e24f78d99ef7f2e[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Jul 7 16:19:38 2015 +0100
+
+    ATLEDGE-158 - Serial.end() not working
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 3f3c4c207f1342ffd17e65e0025f4ab8a9e998dc[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Mon Jul 6 13:02:12 2015 +0100
+
+    Modify pin 19's pin description for EVT board
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit d5bf0344ab8762b716e264eec680970b708f7f1b[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Mon Jul 6 12:50:20 2015 +0100
+
+    Modifify pin 19's pin discription for EVT board
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit a1d94f84bfa3cb7fa164e79b14ba89227d24dea0[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Mon Jul 6 14:04:56 2015 +0100
+
+    ATLEDGE-142: noInterrupt() not working: change delay() behaviour.
+    
+    * Change delay() implementation NOT to enable interrupts before putting the
+      ARC core into sleep state.
+    * delay() still cannot be called from a "no interrupts" context, but it
+      doesn't overwrite the user's settings anymore. In this way, if delay()
+      is called in a no interrupts context, the ARC sleeps for ever.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit de8fab5b63ea28e84055a33b5201d0d44bad0dab[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Mon Jul 6 11:46:10 2015 +0100
+
+    Include Knob example in Servo library
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit ae93ed8d139f36825dcc80bb705d7066af7415c2[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jul 2 13:56:13 2015 +0100
+
+    Shifting out wrong bit index. Should be 7-i instead of 8-i
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 57d3d3dae78e31623c5d60a770f90938df6c1a8d[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Jul 2 10:02:38 2015 +0100
+
+    Implement Servo Library for Intel EDU
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 7ae6ecfc2fec406ea15f8af6d83fb31c3fe45b6e[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Thu Jul 2 13:07:37 2015 +0100
+
+    SPI library implementation for Intel EDU
+    
+    The following functions/features have been implemented:
+    
+    * Standard SPI API:
+        - SPI.begin()
+        - SPI.setClockDivider()
+        - SPI.setDataMode()
+        - SPI.transfer() (single-byte and multi-byte versions)
+        - SPI.transfer16()
+        - SPI.end()
+    * SPI Transaction API
+        - SPI.beginTransaction()
+        - SPI.endTransaction()
+        - SPI.usingInterrupt()
+        - SPI.notUsingInterrupt()
+    * New Intel EDU specific API functions
+        - SPI.transfer24()
+        - SPI.transfer32()
+    
+    Known issues/limitations:
+    * LSBFIRST bit order not supported in hardware, requires (slower) software emulation
+    * SPI Transaction API has not been fully tested at time of writing
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 1cdc4f0688be19e32396d50e731ff3cf16b7d8a6[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Jun 30 15:27:49 2015 +0100
+
+    Update source code with WRS restrictive license headers
+    
+    * Delete arcv2_timer1.[c|h] driver - not used at this stage.
+    * arcv2_timer0 driver: update license header to WRS permissive license;
+      arcv2_timer0.h doesn't exist anymore in the latest Tiny Mountain source
+      code, but we use it, stick in the same WRS permissive license header.
+    * For linker.cmd and flsh.ld linker scripts: replace license header with
+      the WRS permissive one fomr the original linker.cmd files from
+      Tiny Mountain OS
+    * aux_regs.h - derived work from aux_reg.h from Tiny Mountain OS;
+      change license header to WRS permissive.
+    * remove license header as in the original files from thunderdome code
+      base: compiler.h, portable.h
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit c338e4b94124bb619896e8a8c80217e790717ca7[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jun 17 11:02:39 2015 +0100
+
+    ADC Optimization (clock ratio)
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 98fdd4c83861e084c7819d08c3f90e8600675bc6[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Jun 30 14:22:47 2015 +0100
+
+    Arduino core functions: tone/noTone implementation..
+    
+    * tone/noTone implemented using ARC's Timer1.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 32ae6276ac86dd24961eb010297e2239b5ee8b80[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jun 26 15:43:49 2015 +0100
+
+    Arduino core functions: pulseIn(pin, value, timeout)
+    
+    Implementation of pulseIn() Arduino core function using GPIO interrupts
+    and micros() for time-stamping.
+    NOTES:
+    * The performance is not as good as on Arduino UNO. It should be
+    re-measured after following optimisation:
+            * Enable FIRQ (Fast Interrupts) on ARC.
+            * Optimise the GPIO interrupts
+            * Optimise the Timer0 interrupt
+    * Empirical measured accuracy is 10 microseconds.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit cbc40d38c6cd1ef5e433e378c99cc95f19e31fc9[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Fri Jun 26 16:18:29 2015 -0700
+
+    Update sketchUploader version
+    
+    Updated sketchUploader version in platform.txt
+
+[33mcommit 875ec047d28c3059ca215e261bd28f780d0b48d5[m
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jun 26 13:59:13 2015 +0100
+
+    Change to see new VID/PID for ACM devices for baud change reset
+    
+    Must be used with firmware that presents 8087:0A9F as PID/VID
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 11dfe699887f47f65276f880b5a4aaa01f282baa[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Jun 23 17:56:55 2015 +0100
+
+    ATLEDGE-75 - Time: micros()
+    
+    * Re-write micros() function in assembly for a 15-20% performance
+      increase. It should take less than a microsecond now.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 39eb85ad388a7324a24bb17598e2b6b745f209ab[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Tue Jun 23 12:44:16 2015 +0100
+
+    ATLEDGE-84 - Interrupt framework: make interrupt.h C++ compatible.
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 63f6a7698502e7b14798e261be1f2407e06e6a5f[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Jun 17 11:01:10 2015 +0100
+
+    ATLEDGE-82 - ARC Init: Re-enable I-CACHE
+    
+    Enable Instruction cache and invalidate it after interrupt unit device
+    initialisation
+
+[33mcommit 7f98355166f010b00a64cbf7a949b84d96bec05a[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 18 14:13:17 2015 +0100
+
+    updated pre-compiled driver library.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 653e96c9d9b206297d5c631180c41b4cb13e2860[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 18 13:58:40 2015 +0100
+
+    ATLEDGE-27 - Wire (i2c) Library - Moving header files.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 31e4e972141524297a096b38d067593a72af5f6e[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed Jun 17 10:50:00 2015 +0100
+
+    ATLEDGE-75 - Time : delayMicroseconds
+    
+    Implement delayMicroseconds function in Assembly and using the ARC's
+    instructions timing as a reference.
+    The instruction's timing was computed with a scope and using infinite
+    loops, meaning the code most likely used the advantage of ARC'c cache.
+    
+    Function's accuracy is +- 0.15 microseconds in the above stated conditions.
+    The accuracy can be affected by cache miss annd/or interrupts handling.
+    It doesn't disable interrupts and it doesn't use any of the SoC power
+    management features.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit c165e1c12c3918f7dd7e10e05be9550b9fbf1777[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 18 10:20:57 2015 +0100
+
+    ATLEDGE-27 - Wire (i2c) Library
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 648ca2ebcced299f53485e384ea590ff033aafc7[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Jun 16 09:43:33 2015 +0100
+
+    Updated licence headers according to latest files from Intel.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 4c3f58a7e39ee3da55e83d104897b5abdf60c76f[m
+Merge: c2b4f74 d7c5a80
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Jun 9 16:29:48 2015 +0100
+
+    ATLEDGE-82 - merge in change of start address for arc code
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit d7c5a80233d7f574f9060d49f26f102634a50a64[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue Jun 9 15:27:14 2015 +0100
+
+    ATLEDGE-82 - Init: Change linker scripts
+    
+    Modify the start address and the size of the flash area allocated for
+    ARC core, according to ATLASEDGE/WEEKLY/WW23 tag
+
+[33mcommit c2b4f74efc0cafe3ad4aebd365b2457284a7dafe[m
+Merge: b408ea9 a801dd7
+Author: David Hunt <dave@emutex.com>
+Date:   Tue Jun 9 15:16:08 2015 +0100
+
+    Merge branch 'fix_1999' - fix for INPUT_PULLUP
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit b408ea97cbd30aae038381f930995b0f3869702e[m
+Merge: d45290e 539a7c2
+Author: David Hunt <dave@emutex.com>
+Date:   Mon Jun 8 14:20:29 2015 +0100
+
+    feat_irq_uart: Merged serialEvent() functionality.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 539a7c26495321edae81804e9432a5d0c7f88fbb[m
+Author: David Hunt <dave@emutex.com>
+Date:   Mon Jun 8 13:48:55 2015 +0100
+
+    feat_irq_uart - Added in serialEvent() functionality
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit a801dd73b1e5eb41a0bcdb3c50b5a5691ede8f9e[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Mon Jun 8 13:48:20 2015 +0100
+
+    INPUT_PULLUP doesn't appear to enable an internal pull-up resistor
+    
+    Incorrect register base address used by SET_PIN_PULLUP macro in
+    scss_registers.h to enable/disable internal pull-ups
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit d45290e31df7def5c65e1951bd8d3e69347b3843[m
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jun 5 13:49:06 2015 +0100
+
+    Update of precompiled driver library
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 88baee7283dc174131c42b7d0256753f6ee9a906[m
+Merge: ac134d6 79d1ab1
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jun 5 11:22:49 2015 +0100
+
+    ATLEDGE-84 - Interrupt framework
+    
+    Arduino functions implemented:
+      * attachInterrupt(Arduino_Pin, handler, mode):
+         * it works for all Arduino GPIO (IO0 - IO19)
+         * CHANGE mode is supported only for SoC GPIOs (hardware limitation:
+           SS doesn't support interrupt generation on both rising and falling
+           edges.)
+      * detachInterrupt()
+      * interrupts()
+      * noInterrupts()
+    
+    Above functions behaviour is according to Arduino website description.
+    For details please see below references:
+       http://www.arduino.cc/en/Reference/AttachInterrupt
+       http://www.arduino.cc/en/Reference/DetachInterrupt
+       http://www.arduino.cc/en/Reference/Interrupts
+       http://www.arduino.cc/en/Reference/NoInterrupts
+    
+    This implementation uses ss_gpio and soc_gpio drivers from thunderdome.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 79d1ab16a6687015893a83f8bba079fff0e3be6e[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri Jun 5 10:36:30 2015 +0100
+
+    ATLAEDGE-84: Interrupt framework
+    
+    Arduino functions implemented:
+      * attachInterrupt(Arduino_Pin, handler, mode):
+         * it works for all Arduino GPIO (IO0 - IO19)
+         * CHANGE mode is supported only for SoC GPIOs (hardware limitation:
+           SS doesn't support interrupt generation on both rising and falling
+           edges.)
+      * detachInterrupt()
+      * interrupts()
+      * noInterrupts()
+    
+    Above functions behaviour is according to Arduino website description.
+    For details please see below references:
+       http://www.arduino.cc/en/Reference/AttachInterrupt
+       http://www.arduino.cc/en/Reference/DetachInterrupt
+       http://www.arduino.cc/en/Reference/Interrupts
+       http://www.arduino.cc/en/Reference/NoInterrupts
+    
+    This implementation uses ss_gpio and soc_gpio drivers from thunderdome.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit ac134d6f742532d9c43783b29c5d145ab8306054[m
+Merge: 77d7a18 d7cbbf4
+Author: David Hunt <dave@emutex.com>
+Date:   Fri Jun 5 10:09:17 2015 +0100
+
+    ATLEDGE-14 - Added wiring-shift functionality
+    
+    shiftIn() and shiftOut()
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit d7cbbf4f4bb3abee46f887ee8adbcb9e851594c9[m
+Author: davids <david.silva@emutex.com>
+Date:   Fri Jun 5 09:23:44 2015 +0100
+
+    implement wiring_shift.c()
+
+[33mcommit da2e44848abcb12f4f6c9a891a55425b330fdb25[m
+Author: davids <david.silva@emutex.com>
+Date:   Thu Jun 4 15:20:53 2015 +0100
+
+    implement wiring_shift()
+
+[33mcommit 77d7a180c96bb25b69cc82de14e37104dcc77707[m
+Merge: de3666c 941f594
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 4 14:44:52 2015 +0100
+
+    ATLEDGE-83 - Integrating Component Framework IPC with Arduino run-time lib
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit de3666c598909ffd19079a6e5390559e3435812b[m
+Merge: 59634af 325da1d
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 4 14:27:36 2015 +0100
+
+    ATLEDGE-15 - Analog In functions
+
+[33mcommit 941f594f9fbdc201af1539678e3cd30c9dc8b09d[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Wed Jun 3 10:25:40 2015 +0100
+
+    cfw: Integrating Component Framework IPC with Arduino run-time lib
+    
+    Adding glue layer to initialise CFW and enable interrupt-driven
+    handling of received messages from LMT core
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit cdf2107957c9c8d17ee0667cb754a31d242c75a5[m
+Author: davids <david.silva@emutex.com>
+Date:   Thu Jun 4 11:35:13 2015 +0100
+
+    implement wiring_shift()
+
+[33mcommit 325da1ded53cd4a533c7cd4c2782fa3fbe1dc30c[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Jun 4 03:35:04 2015 -0700
+
+    analogRead fixes
+
+[33mcommit 57310fed13bdf80a77a24b663925ff28b4595bc2[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Thu Jun 4 03:15:40 2015 -0700
+
+    analogRead fixes:
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit 59634aff378b89deb36041d94aed7132e5588b37[m
+Merge: e60cba4 530ba96
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 4 10:17:03 2015 +0100
+
+    ATLEDGE-76 - Serial functions, addition of interrupt handling
+
+[33mcommit 530ba96203602f7743aac12175c08e4b5ddf0209[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu Jun 4 09:52:07 2015 +0100
+
+    feat_irq_uart: minor changes after code reviews
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit f0b0954a09cf5808fa87abf8052a088f5ee5e5bd[m
+Author: davids <david.silva@emutex.com>
+Date:   Wed Jun 3 17:42:21 2015 +0100
+
+    implement wiring_shift()
+
+[33mcommit 65e2c057260887613e173a274bb439c92bb8141c[m
+Author: Kevin Moloney <kevin.moloney@emutex.com>
+Date:   Wed Jun 3 07:24:48 2015 -0700
+
+    adc: Implement analogRead()
+    
+    Signed-off-by: Kevin Moloney <kevin.moloney@emutex.com>
+
+[33mcommit acde269f698e087f6e2d23f498576c720dc91c07[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed Jun 3 11:19:39 2015 +0100
+
+    feat_irq_uart: enable UART interrupt handling
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit e60cba4bcb0e03c4fd8158d9b1226c023e016f19[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu May 28 13:56:49 2015 +0100
+
+    feat_strings: add -fno-exceptions for C++ code to remove linker errors
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 81123d478ae1747a9f1148c0270395d95ba62ef8[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu May 28 12:03:33 2015 +0100
+
+    feat_strings: Compiler & linker flags for String builds
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit d72c26f1c38ef35556dd1faf832b0be8e9c7dd60[m
+Merge: 07a494f d1289bb
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed May 27 18:05:56 2015 +0100
+
+    ATLEDGE-82: Init - change ARC memory layout.
+    
+    * Change start address and size of the Flash area allocated to the ARC core
+      according to new memory layout received from Toulouse.
+    
+     Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit d1289bbdbfdad34ecac16de752237aba65a942ef[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Wed May 27 09:06:25 2015 +0100
+
+    ATLEDGE-82: Init - change ARC memory layout.
+    
+    * Change start address and size of the Flash area allocated to the ARC core
+      according to new memory layout received from Toulouse.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 07a494f00158248b1100ad4ba1e240ad0221bfc0[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu May 21 15:43:55 2015 +0100
+
+    Adding updated pre-compiled driver library.
+    Cleaning up after code reviews and validation of build.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit e77ff7a37c2bd3a00199471cbc328d7bf338b87b[m
+Author: David Hunt <dave@emutex.com>
+Date:   Thu May 21 14:08:03 2015 +0100
+
+    Updated due to code reviews
+    
+    * Fix delay() issue
+            Issue: If value of microsecond is Timer0 limit, arcv2_timer0_count_get()
+            microseconds condition will always be true, spinning for ever.
+            The main issue is that the time between 2 consecutive readings of
+            COUNT0 register is around 90 ticks and the Timer may overflow
+            before the next reafing of COUNT0 if last values read > LIMIT - 90.
+            Fix: Take in consideration the number of overflows. If TIMER0 overflows
+            just leave the loop (even if COUNT0 < microseconds)
+    * Restructure a bit arcv2_timer0_enable() function in order to reflect the
+          procedure described in chapter 3.3.76.1 of DesignWare ARCv2 ISA
+          Programmer's Reference Manual.
+          Make sure Timer0 initialisation clears the counter register as well.
+    * code review - added yield via hooks.c
+    * added back in strip stage when building
+    * Remove unused code in os.h, os_types.h and pf_init.h
+    * Uncomment call to yield() from delay() Arduino function; yield() is
+          added for sake of compatibility.
+    * Remove dead code from timer0 init function.
+    * Commented out enable instruction cache
+    * Added Copyright header to wiring.c
+    * Setup automatic (hardware) context saving feature for non-fast interrupts
+    * Serial Communication API Initial checkin of Serial.read() and Serial.write()
+      using header pins 0 and 1
+    * Eliminated some compiler warnings.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit c4fad8ecba577bfd28171c31b14aab47a465754a[m
+Merge: 9ec6faf e187e5e
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 14:05:37 2015 +0100
+
+    ATLEDGE82 init code
+    
+    small cleanup around interrupt init code.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit e187e5ed742bd85ecafa6cde5dfa3ad35ec90bb9[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Tue May 19 13:42:45 2015 +0100
+
+    ATLEDGE-82 init code
+    
+    Minor tidy-up to interrupt init code
+    
+    Currently, timer init functions enable global interrupts.  This should
+    be done in the interrupt setup code during the chip init sequence.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 9ec6fafc1665504fe90fc99623f1348267caeed9[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 13:13:45 2015 +0100
+
+    ATLEDGE-82 init code
+    
+    final cleanup before push. no functional changes.
+
+[33mcommit d37176a3b8483127244c5c72bad861ef4598d756[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 12:56:33 2015 +0100
+
+    ATLEDGE-82 init code
+    
+    Interrupt handling - add hw context saving
+    
+    * Disable instruction cache (we don't need it at this stage)
+    * Setup automatic (hardware) context saving feature for non-fast
+      interrupts.
+    * Set optimization to none (-O0) in Makefile.
+    
+    build: Eliminating compiler warnings
+    
+    Fix interrupt handling bug
+    
+        Issue:
+            A simple blink sketch having a 10 ms delay between blinks crashed
+            after a few seconds.
+            It looks like the stack got corrupted.
+        Root cause:
+            The generic assembly hardware ISR, "_do_isr", was not properly
+            written; the "sp" was not properly handled.
+        Solution:
+            Replace the assembly hardware ISR with a C function having
+            "__attribute__((interrupt("ilink")))"
+    
+        Note:
+            We need this generic hardware ISR because the IVT is in flash and
+            we cannot change it at runtime.
+    
+    Allocating more SRAM to ARC (syncing with latest Thunderdome mem allocation)
+    
+    build: Removing sdata section declaration from linker scripts
+    
+        ARC doesn't support an SDATA section bigger than 1024 bytes, and
+        we overflow this too easily when we link in code that hasn't been
+        compiled with the -mno-sdata compiler flag.  So we will ensure that
+        we only use code compiled with -mno-sdata (including standard C lib)
+        and we remove this section declaration to weed out any exceptions to this.
+        In other words, if we link any code that tries to use the sdata section,
+        we will see a linker error.
+    
+    build: Adding HEAP section
+    
+        Adding heap section with start/end marker symbols to satisfy
+        malloc() and friends
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit d4fe5885d8e2bebd071e4e7d378d3fbf8e85a2eb[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Mon May 18 11:12:35 2015 +0100
+
+    ATLEDGE-82 init code
+    
+    Interrupt handling - add hw context saving
+    
+    * Disable instruction cache (we don't need it at this stage)
+    * Setup automatic (hardware) context saving feature for non-fast
+      interrupts.
+    * Set optimization to none (-O0) in Makefile.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+    
+    Author:    Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit 82c3529091c7c2d1f13d1d55c3d31cdf0aa56840[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri May 15 16:25:07 2015 +0100
+
+    ATLEDGE-82 init code for arc
+    
+    Eliminating compiler warnings and cleanup.
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+    
+    Conflicts:
+            system/libarc32_edu/drivers/ns16550.c
+            system/libarc32_edu/drivers/uart.h
+            system/libarc32_edu/main.c
+
+[33mcommit 4a29f5c30fb52e433f30c1ab7ba30244953e2d05[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri May 15 14:46:08 2015 +0100
+
+    cfw: Importing Component Framework library code from Thunderdome
+    
+    Framework code extracted from the following commit ID in
+    Intel's thunderdome git repo: 8b198659675cd820072bdeb00d0c5de87c6f6ee2
+    
+    This brings the necessary library code into the source tree, but not
+    yet integrated in the Arduino run-time environment (to follow shortly).
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit c2f3e0413c6e1c4567faedd5b2e7a8308fc8c42e[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Fri May 15 14:24:10 2015 +0100
+
+    ATLEDGE-82 init code - Fix interrupt handling bug.
+    
+    Issue:
+        A simple blink sketch having a 10 ms delay between blinks crashed
+        after a few seconds.
+        It looks like the stack got corrupted.
+    Root cause:
+        The generic assembly hardware ISR, "_do_isr", was not properly
+        written; the "sp" was not properly handled.
+    Solution:
+        Replace the assembly hardware ISR with a C function having
+        "__attribute__((interrupt("ilink")))"
+    
+    Note:
+        We need this generic hardware ISR because the IVT is in flash and
+        we cannot change it at runtime.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 723be266ea682a413efca74e5b69190e17bf2a65[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Fri May 15 14:49:26 2015 +0100
+
+    Allocating more SRAM to ARC (syncing with latest Thunderdome mem allocation)
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit b9bc0fb221574f5f5a52abfa1d9d2b3da85fc1ba[m
+Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+Date:   Tue May 12 21:31:11 2015 +0100
+
+    .gitignore file added to repo.
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+
+[33mcommit bd205779390d879a5e866941b840e5094204c97c[m
+Author: Dan O'Donovan <dan@emutex.com>
+Date:   Tue May 12 17:47:54 2015 +0100
+
+    build: Adding HEAP section
+    
+    Adding heap section with start/end marker symbols to satisfy
+    malloc() and friends
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+
+[33mcommit 4139a2efcdee1b210933b7abeee2bea084d1b369[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 12:06:17 2015 +0100
+
+    ATLEDGE-75 Arduino time related functions.
+    
+    A first draft for the following functions:
+        * delay()
+        * millis();
+        * micros();
+    Not yet implemented:
+        * delayMicroseconds.
+    
+    Author: Bogdan Pricop <bogdan.pricop@emutex.com>
+    
+    Signed-off-by: Bogdan Pricop <bogdan.pricop@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 3689741b718ce769a50515d661a7ebf13cf733be[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 11:58:55 2015 +0100
+
+    ATLEDGE-24 Serial Communication API
+    
+    Intial release of serial functionality, Serial.write, print, println, read
+    Also added files required, Ringbuffer (not used yet), Print, etc.
+    Also some small changes to make Intel toolchain work, still more work needed.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 57550ebb85d6f69dc52cefcf38f47a7995f708b3[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 11:52:19 2015 +0100
+
+    ATLEDGE-83 Component Framework integration into bare metal
+    
+    Author: Dan O'Donovan <dan@emutex.com>
+    Date:   Fri May 15 14:46:08 2015 +0100
+    
+    Framework code extracted from the following commit ID in
+    Intel's thunderdome git repo: 8b198659675cd820072bdeb00d0c5de87c6f6ee2
+    
+    This brings the necessary library code into the source tree, but not
+    yet integrated in the Arduino run-time environment (to follow shortly).
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit ed4bf0214f53df5b8c255ed6f575fcdc6bf361d3[m
+Author: David Hunt <dave@emutex.com>
+Date:   Tue May 19 11:48:40 2015 +0100
+
+    ATLEDGE-15 basic analog functions
+    
+    Adding analogWriteResolution and analogReadResolution
+    
+    Signed-off-by: Dan O'Donovan <dan@emutex.com>
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 32aff42d8023cafcb6b5b86820e455b1914ecf55[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed May 6 17:14:51 2015 +0100
+
+    ATLEDGE-62 Create Initial Release of Arduino Corelibs
+    
+    Adding licence headers to those files that don't have any.
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit 09a6c2ea91c99a7f8e3aff45cb4bc7f3e501a715[m
+Author: David Hunt <dave@emutex.com>
+Date:   Wed May 6 14:50:40 2015 +0100
+
+    ATLEDGE-62 Create Initial Release of Arduino Corelibs
+    
+    Allows Arduino IDE to build Blink Sketch
+    Includes pinMode(), digitalWrite() and delay()
+    Allows download via JTAG
+    
+    Signed-off-by: David Hunt <dave@emutex.com>
+
+[33mcommit a5ca45cc6a31e8775363fa6c3f0c32e337945a43[m
+Author: Dino Tinitigan <bigdinotech@gmail.com>
+Date:   Thu Apr 16 14:05:33 2015 -0700
+
+    Initial commit of core files
+    
+    Initial commit of core files
+
+[33mcommit 631d399bf35241b823ae74b3b4dc6b27d303078e[m
+Author: Calvin Park <calvin.s.park@intel.com>
+Date:   Thu Apr 16 13:29:04 2015 -0700
+
+    Initial commit


### PR DESCRIPTION
-compatibility changes for CDC-ACM usb serial to work with upcoming
CODK-M based firmware
-use a fixed delay between writes instead of trying to mimick UART
throttling