### PR TITLE
Jira 857, BLEPeripheral::connected() always returns false, git 444

### DIFF
--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -146,7 +146,8 @@ BLECentral BLEPeripheral::central(void)
 
 bool BLEPeripheral::connected(void)
 {
-    return BLE.connected();
+    BLEDevice centralBle = BLE.central();
+    return centralBle.connected();
 }
 
 void BLEPeripheral::init()


### PR DESCRIPTION
Root casue:
  - The stack need use connected device to get the state.
  - The current code used local address to get the link and get an error.

Code mods:

1. BLEPeripheral.cpp:
   - Use central's address to get connection state.