### PR TITLE
Jira 858, Can't trigger BLEConnected, BLEDisconnected events, git 445

### DIFF
--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -155,7 +155,6 @@ void BLEPeripheral::init()
     if (!_initCalled)
     {
         BLE.begin();
-        memset(m_eventHandlers, 0, sizeof(m_eventHandlers));
         _initCalled = true;
     }
 }


### PR DESCRIPTION
Root casue:
  - The callback regiter before the begin and the begin
    reset the callback.

Code mods:
1. BLEPeripheral.cpp:
   - Remove clearing of callback register array at begin(). The
     array is cleared upon system initialization.