### PR TITLE
Jira 802, BLE Central scan() to filter Peripheral adv, git #369

### DIFF
--- a/libraries/CurieBLE/src/BLECommon.h
+++ b/libraries/CurieBLE/src/BLECommon.h
@@ -103,6 +103,7 @@ typedef ble_status_t BleStatus;
 
 #define BLE_MAX_CONN_CFG            2
 #define BLE_MAX_ADV_BUFFER_CFG      3
+#define BLE_MAX_ADV_FILTER_SIZE_CFG 20
 
 typedef bool (*ble_advertise_handle_cb_t)(uint8_t type, const uint8_t *dataPtr,
                                           uint8_t data_len, const bt_addr_le_t *addrPtr);

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -362,6 +362,8 @@ private:
                                   const uint8_t* &adv_data,
                                   uint8_t &adv_len) const;
     bool disconnectSingle(const bt_addr_le_t *peer);
+    void updateDuplicateFilter(const bt_addr_le_t* addr);    
+    bool deviceInDuplicateFilterBuffer(const bt_addr_le_t* addr);
 
 private:
     uint16_t   _min_conn_interval;
@@ -432,6 +434,10 @@ private:
     uint8_t    _peer_peripheral_adv_data[BLE_MAX_CONN_CFG][BLE_MAX_ADV_SIZE];
     uint8_t    _peer_peripheral_adv_data_len[BLE_MAX_CONN_CFG];
     uint8_t    _peer_peripheral_adv_rssi[BLE_MAX_CONN_CFG];
+    bt_addr_le_t _peer_duplicate_address_buffer[BLE_MAX_ADV_FILTER_SIZE_CFG];
+    uint8_t     _duplicate_filter_header;
+    uint8_t     _duplicate_filter_tail;
+    bool        _adv_duplicate_filter_enabled;
 
     BLEDeviceEventHandler _device_events[BLEDeviceLastEvent];
 };


### PR DESCRIPTION
New feature:
  - Request from Arduino to make our Central BLE library to
    scan Peripheral similar to an Apple device.
  - When filter is set, advertisement from a Peripheral will
    only show up once (until scan is stop and start again) with
    the available() call.  Otherwise, a Peripheral will appear
    as often as the Central can detect its advertisement.
  - Unlike an Apple device, the 101 operates under memory
    constraints.  Thus, the maximum number of filter entries
    is limited to 20.  In other words, if ther are more than
    20 Peripherals, the filter will NOT be able to filter out
    all the advertisement all the time.  A Peripherla WILL
    show up multiple times when available() is called.

Code mods:
1. BLECommon.h:
   - Definition of the filter entries size.
2. BLEDeviceManager.cpp:
   - Peripheral filtering initialization at
     startScanningWithDuplicates().
   - Added deviceInDuplicateFilterBuffer() for search a newly
     detected Peripheral against a recorded list of devices.
   - Added updateDuplicateFilter() to record any newly
     detected Peripoheral.
   - At available(), check for duplicated Peripheral prior
     to return it to caller.  Discard any reported Peripheral.
     Record any newly detected one prior to return it to
     caller.