### PR TITLE
Jira 824, BLE Peripheral to create Scan Response Data

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -133,6 +133,17 @@ void BLEDevice::setManufacturerData(const unsigned char manufacturerData[],
     BLEDeviceManager::instance()->setManufacturerData(manufacturerData, manufacturerDataLength);
 }
 
+bool BLEDevice::getManufacturerData (unsigned char* manu_data, 
+                                     unsigned char& manu_data_len) const
+{
+    return BLEDeviceManager::instance()->getManufacturerData(this, manu_data, manu_data_len);
+}
+
+bool BLEDevice::hasManufacturerData() const
+{
+    return BLEDeviceManager::instance()->hasManufacturerData(this);
+}
+
 void BLEDevice::setLocalName(const char *localName)
 {
     BLEDeviceManager::instance()->setLocalName(localName);

--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -191,6 +191,11 @@ class BLEDevice
     void setManufacturerData(const unsigned char manufacturerData[], 
                              unsigned char manufacturerDataLength);
     
+    bool getManufacturerData (unsigned char* manu_data, 
+                              unsigned char& manu_data_len) const;
+    
+    bool hasManufacturerData() const;
+    
     /**
      * Set the local name that the BLE Peripheral Device advertises
      *


### PR DESCRIPTION
Feature added:
  - Arduino request that the BLE library, in Peripheral mode,
    to support Scan Response Data request from a Central.
  - Arduino expects the reply similar to an Apple device.
    They have provide a policy for the construction of the
    Scan Response data message.

Code mods:
1. BLEDeviceManager.cpp:
   - Added setAdvertiseData() for the creation of the Scan
     Response Data message.
   - In advDataInit(), follows the policy (defined by
     Arduino) to add Adv data to the Scan Response
     Data message using setAdvertiseData().
2. BLEDeviceManager.h:
   - prototypeing.




