### PR TITLE
Jira 836, Enumerate non connectable Peripherals in Central scan

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -133,6 +133,17 @@ void BLEDevice::setManufacturerData(const unsigned char manufacturerData[],
     BLEDeviceManager::instance()->setManufacturerData(manufacturerData, manufacturerDataLength);
 }
 
+bool BLEDevice::getManufacturerData (unsigned char* manu_data, 
+                                     unsigned char& manu_data_len) const
+{
+    return BLEDeviceManager::instance()->getManufacturerData(this, manu_data, manu_data_len);
+}
+
+bool BLEDevice::hasManufacturerData() const
+{
+    return BLEDeviceManager::instance()->hasManufacturerData(this);
+}
+
 void BLEDevice::setLocalName(const char *localName)
 {
     BLEDeviceManager::instance()->setLocalName(localName);

--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -191,6 +191,11 @@ class BLEDevice
     void setManufacturerData(const unsigned char manufacturerData[], 
                              unsigned char manufacturerDataLength);
     
+    bool getManufacturerData (unsigned char* manu_data, 
+                              unsigned char& manu_data_len) const;
+    
+    bool hasManufacturerData() const;
+    
     /**
      * Set the local name that the BLE Peripheral Device advertises
      *


### PR DESCRIPTION
Added feature:
  - In Central mode, the BLE library should enumerate Peripheral
    that are non-connectable (eg beacon).

Code Mods:
1. BLEDevice.cpp:
   - Add the call to get Manufacturer Data info from a
     Peripheral.  Non-connectable device may only broadcast
     this info.
2. BLEDevice.h:
   - Prototyping.
3. BLEDeviceManager.cpp:
   - Delete the filter about non-connectable advertisement.
   - Added APIs, hasManufacturerData(), setManufacturerData(),
     hasManufacturerData(), to gain access to adv info
     of non-connectable Peripherals.
