### PR TITLE
Jira 867, BLE setValue(), add support for strings, git #210

### DIFF
--- a/libraries/CurieBLE/src/BLECharacteristic.cpp
+++ b/libraries/CurieBLE/src/BLECharacteristic.cpp
@@ -248,6 +248,11 @@ bool BLECharacteristic::setValue(const unsigned char value[], unsigned short len
     return writeValue(value, (int)length);
 }
 
+bool BLECharacteristic::setValue(const char* value)
+{
+    return this->setValue((const unsigned char *)value, strlen(value));
+}
+
 bool BLECharacteristic::writeValue(const byte value[], int length)
 {
     return writeValue(value, length, 0);

--- a/libraries/CurieBLE/src/BLECharacteristic.h
+++ b/libraries/CurieBLE/src/BLECharacteristic.h
@@ -181,6 +181,15 @@ public:
     bool setValue(const unsigned char value[], unsigned short length);
 
     /**
+     * Set the current value of the Characteristic with a String
+     *
+     * @param value New string value to set, strings exceeding maxLength will be truncated
+     *
+     * @return bool true set value success, false on error
+     */
+     bool setValue(const char* value);
+
+    /**
      * @brief   Write the value of the characteristic
      *
      * @param   value   The value buffer that want to write to characteristic


### PR DESCRIPTION
Feature added:
  - This is directly pulled from Arduino community PR #210.
    Overloading the setValue() method to take in a string
    as the only input parameter, instead of a pointer
    and its size.