### PR TITLE
GIT #456 large characteristics crash board when attempting to write t…

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -77,7 +77,13 @@ ssize_t profile_longwrite_process(struct bt_conn *conn,
                                      const void *buf, uint16_t len,
                                      uint16_t offset)
 {
-    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)attr->user_data;
+    BLEAttribute *bleattr = (BLEAttribute *)attr->user_data;
+    BLEAttributeType type = bleattr->type();
+    if (BLETypeCharacteristic != type)
+    {
+        return 0;
+    }
+    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)bleattr;
     
     blecharacteritic->setBuffer((const uint8_t *) buf, len, offset);
     
@@ -88,7 +94,13 @@ int profile_longflush_process(struct bt_conn *conn,
                               const struct bt_gatt_attr *attr, 
                               uint8_t flags)
 {
-    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)attr->user_data;
+    BLEAttribute *bleattr = (BLEAttribute *)attr->user_data;
+    BLEAttributeType type = bleattr->type();
+    if (BLETypeCharacteristic != type)
+    {
+        return 0;
+    }
+    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)bleattr;
 
     switch (flags)
     {


### PR DESCRIPTION
…o them

Root cause:
1. The typecast order is not correct make the class's offset has an error
    and make the memcpy used wrong address and wrong length.

Solution:
1. Adjust the typecast order, from base type to child type, in BLECallbacks.cpp