### PR TITLE
Jira 868, BLE Peripheral stack crash with long write, git456

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -77,7 +77,13 @@ ssize_t profile_longwrite_process(struct bt_conn *conn,
                                      const void *buf, uint16_t len,
                                      uint16_t offset)
 {
-    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)attr->user_data;
+    BLEAttribute *bleattr = (BLEAttribute *)attr->user_data;
+    BLEAttributeType type = bleattr->type();
+    if (BLETypeCharacteristic != type)
+    {
+        return 0;
+    }
+    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)bleattr;
     
     blecharacteritic->setBuffer((const uint8_t *) buf, len, offset);
     
@@ -88,7 +94,13 @@ int profile_longflush_process(struct bt_conn *conn,
                               const struct bt_gatt_attr *attr, 
                               uint8_t flags)
 {
-    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)attr->user_data;
+    BLEAttribute *bleattr = (BLEAttribute *)attr->user_data;
+    BLEAttributeType type = bleattr->type();
+    if (BLETypeCharacteristic != type)
+    {
+        return 0;
+    }
+    BLECharacteristicImp *blecharacteritic = (BLECharacteristicImp*)bleattr;
 
     switch (flags)
     {


### PR DESCRIPTION
Root cause:
  - Upon processing the write event, The received user data
    was casted incorrectly using the base class.  Resulted
    in using an incorrect offset that caused memcpy to
    use incorrect address and length.

Code Mods:
  1. BLECallbacks.cpp:
     Adjust the typecast order, from base class to child
     class in profile_longwrite_process() and
     profile_longflush_process().