### PR TITLE
Jira 870, Change sensortag_button.ino to use localName

### DIFF
--- a/libraries/CurieBLE/examples/central/sensortag_button/sensortag_button.ino
+++ b/libraries/CurieBLE/examples/central/sensortag_button/sensortag_button.ino
@@ -43,23 +43,12 @@ void loop() {
     Serial.print(peripheral.advertisedServiceUuid());
     Serial.println();
 
-    /*see if peripheral is a SensorTag
-      The localName SensorTag is in the Scan Response data packet
-      In this release we do not have the feature that gets the scan response data and hence
-      the local name in the scan is blank
-      We have to explicitly find the BLE mac address
-      Please use another deviice like nrfConnect app to discover the Bluetooth Address
-    */
-    //if (peripheral.localName() == "SensorTag") {
-
-
-    /******************************************************
-    * ATTENTION:
-    * Change to the mac address according to your device!
-    * Use a central app that can display the BT MAC address
-    * ******************************************************
-    */
-    if (peripheral.address() == "68:C9:0B:06:BC:81") {
+    /* see if peripheral is a SensorTag
+     * The localName, CC2650 SensorTag, is in the Scan Response Data packet.
+     * If this is not the expected name, please change the following
+     * if-statement accordingly.
+     */
+    if (peripheral.localName() == "CC2650 SensorTag") {
       // stop scanning
       BLE.stopScan();
 


### PR DESCRIPTION
Feature added:
  - Since the BLE library now support the Scan
    Response Data processing, update the sketch
    to look for the sensorTag localName instead
    of its specific unit address.

Cod mods:
1. sensortag_button.ino:
   - Replace MAC address comparison with localName
     string comparison.