### PR TITLE
-add error functions

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -110,6 +110,7 @@ extern uint8_t pinmuxMode[NUM_DIGITAL_PINS];
 #include "WMath.h"
 #include "HardwareSerial.h"
 #include "wiring_pulse.h"
+#include "error.h"
 
 #endif // __cplusplus
 

--- a/cores/arduino/error.cpp
+++ b/cores/arduino/error.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2017 Intel Corporation.  All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#include "error.h"
+
+void error_continue()
+{
+    error_continue(1);
+}
+
+void error_continue(uint8_t error_code)
+{
+    uint32_t exc_addr = aux_reg_read(ARC_V2_EFA);
+    uint32_t ecr = aux_reg_read(ARC_V2_ECR);
+
+    pr_error(0, "Exception vector: 0x%x, cause code: 0x%x, parameter 0x%x\n",
+    ARC_V2_ECR_VECTOR(ecr),
+    ARC_V2_ECR_CODE(ecr),
+    ARC_V2_ECR_PARAMETER(ecr));
+    pr_error(0, "Address 0x%x\n", exc_addr);
+    shared_data->error_code = error_code;
+}
+
+void error_halt()
+{
+    error_halt(1);
+}
+
+void error_halt(uint8_t error_code)
+{
+    error_continue(error_code);
+    __asm__("flag 0x01") ; /* Halt the CPU */
+}

--- a/cores/arduino/error.h
+++ b/cores/arduino/error.h
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2017 Intel Corporation.  All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#ifndef _Error_h
+#define _Error_h
+
+#include <stdint.h>
+#include "os/os.h"
+#include "infra/log.h"
+#include "aux_regs.h"
+#include "platform.h"
+
+extern void error_halt();
+
+extern void error_halt(uint8_t error_code);
+
+extern void error_continue();
+
+extern void error_continue(uint8_t error_code);
+
+#endif

--- a/system/libarc32_arduino101/framework/include/platform.h
+++ b/system/libarc32_arduino101/framework/include/platform.h
@@ -156,6 +156,8 @@ struct platform_shared_block_ {
     void* quark_restore_addr;
     
     uint32_t pm_int_status;
+    
+    uint8_t error_code;
 };
 
 #define RAM_START           0xA8000000


### PR DESCRIPTION
-add error functions that sets an error_code variable in shared memory
and halt the ARC core
-this will be used by CODK-M based firmware to toggle the fault led on
the Arduino 101