### PR TITLE
Modify comments to point to Paul Stoffregen's Serial Flash library

### DIFF
--- a/libraries/CurieSerialFlash/examples/CopyFromSerial/CopyFromSerial.ino
+++ b/libraries/CurieSerialFlash/examples/CopyFromSerial/CopyFromSerial.ino
@@ -58,7 +58,8 @@
  *
  * SerialFlash library API: https://github.com/PaulStoffregen/SerialFlash
  *
- * This example depens on http://librarymanager/all#SerialFlash&SPI (clickme!)
+ * This example depends on Paul Stoffregen's SerialFlash library.
+ * Download at https://github.com/PaulStoffregen/SerialFlash.
  */
 
 #include <CurieSerialFlash.h>

--- a/libraries/CurieSerialFlash/examples/EraseEverything/EraseEverything.ino
+++ b/libraries/CurieSerialFlash/examples/EraseEverything/EraseEverything.ino
@@ -1,4 +1,5 @@
-// This example depens on http://librarymanager/all#SerialFlash&SPI (clickme!)
+// This example depends on Paul Stoffregen's SerialFlash library
+// Download at https://github.com/PaulStoffregen/SerialFlash
 
 #include <CurieSerialFlash.h>
 #include <SPI.h>

--- a/libraries/CurieSerialFlash/examples/FileWrite/FileWrite.ino
+++ b/libraries/CurieSerialFlash/examples/FileWrite/FileWrite.ino
@@ -1,4 +1,5 @@
-// This example depens on http://librarymanager/all#SerialFlash&SPI (clickme!)
+// This example depends on Paul Stoffregen's SerialFlash library
+// Download at https://github.com/PaulStoffregen/SerialFlash
 
 #include <CurieSerialFlash.h>
 #include <SPI.h>

--- a/libraries/CurieSerialFlash/examples/ListFiles/ListFiles.ino
+++ b/libraries/CurieSerialFlash/examples/ListFiles/ListFiles.ino
@@ -1,4 +1,5 @@
-// This example depens on http://librarymanager/all#SerialFlash&SPI (clickme!)
+// This example depends on Paul Stoffregen's SerialFlash library
+// Download at https://github.com/PaulStoffregen/SerialFlash
 
 #include <CurieSerialFlash.h>
 #include <SPI.h>

--- a/libraries/CurieSerialFlash/examples/RawHardwareTest/RawHardwareTest.ino
+++ b/libraries/CurieSerialFlash/examples/RawHardwareTest/RawHardwareTest.ino
@@ -19,8 +19,8 @@
 // You MUST post the complete output of this program, and
 // the exact part number and manufacturer of the chip.
 //
-// This example depens on http://librarymanager/all#SerialFlash&SPI (clickme!)
-
+// This example depends on Paul Stoffregen's SerialFlash library
+// Download at https://github.com/PaulStoffregen/SerialFlash
 
 #include <CurieSerialFlash.h>
 #include <SPI.h>


### PR DESCRIPTION
The current comments in the CurieSerialFlash examples has the library manager shortcut and the user will be downloading the versions 1.0 to 4.0, but these versions will not work with these examples and compilation fails. The user instead should be instructed to get the current working library version from github at https://github.com/PaulStoffregen/SerialFlash