### PR TITLE
Fix Jira876 BLE scanForName() device from previous scan is picked up

### DIFF
--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -358,6 +358,7 @@ private:
                                    const uint8_t* data, 
                                    uint8_t length);
     BLE_STATUS_T _advDataInit(void);
+    void _clearAdvertiseBuffer();
     bool advertiseDataProc(uint8_t type, 
                            const uint8_t *dataPtr, 
                            uint8_t data_len);


### PR DESCRIPTION
Root cause:
1. The buffer doesn't cleared. The scanned data is not the latest.

Changed files:
BLEDeviceManager.cpp
  a. Clear the buffered data when start scan.
  b. Invalid scan response when buffer timeout or disconnected.