### PR TITLE
Jira 798, Adjust ARC SRAM to BLE scan the SensorTag, git 373

### DIFF
--- a/variants/arduino_101/linker_scripts/flash.ld
+++ b/variants/arduino_101/linker_scripts/flash.ld
@@ -40,7 +40,7 @@ OUTPUT_FORMAT("elf32-littlearc", "elf32-bigarc", "elf32-littlearc")
 MEMORY
     {
     FLASH                 (rx) : ORIGIN = 0x40034000, LENGTH = 152K
-    SRAM                  (wx) : ORIGIN = 0xa800e000, LENGTH = 24K
+    SRAM                  (wx) : ORIGIN = 0xa800bc00, LENGTH = 32K
     DCCM                  (wx) : ORIGIN = 0x80000000, LENGTH = 8K
     }
 
@@ -52,7 +52,7 @@ __firq_stack_size = 1024;
 
 /* Minimum heap size to allocate
  * Actual heap size might be bigger due to page size alignment */
-__HEAP_SIZE_MIN = 8192;
+__HEAP_SIZE_MIN = 16384;
 /* This should be set to the page size used by the malloc implementation */
 __PAGE_SIZE = 4096;
 


### PR DESCRIPTION
Feature requested:
    Arduino requires the BLE stack, in Central mode, be able to completely record all Attributes from the TI SensorTag.  There about 100+ Attributes and each requires buffering space in additional to the normal memory consumption of storing an Attribute.  Thus, a substantial increase in the HEAP memory (SRAM) size is needed.
   Please note that the change in SRAM arrangement affects both cores:  x86 and ARC.  Thus, image for both cores need to be updated together.  This PR addresses only the ARC core.

Code Mods:
  1.  flash.ld - Update the RAM memory map to reflect the new ARC SRAM starting memory.

WARNING:
  -  This PR needs the x86 f/w to be updated with this PR,
        https://github.com/01org/CODK-M-X86/pull/24

