### PR TITLE
CurieBLE: Set characteristic value internally if it not associated with a service yet

### DIFF
--- a/libraries/CurieBLE/src/BLECharacteristic.cpp
+++ b/libraries/CurieBLE/src/BLECharacteristic.cpp
@@ -283,6 +283,10 @@ bool BLECharacteristic::writeValue(const byte value[], int length, int offset)
                                                                    characteristicImp->valueLength());
             BLEDeviceManager::instance()->startAdvertising();
         }
+    } else {
+        // not associated with a service yet
+        _setValue(value, length);
+        retVar = true;
     }
     return retVar;
 }


### PR DESCRIPTION
Resolves #366.

As outlined in the sketch provided in https://github.com/01org/corelibs-arduino101/issues/366#issue-198057880.

The initial value of 0x00 that was set by the type characteristic was dropped because it has not been associated with a service yet via `addCharacteristic(...)`. This change stores the value internally like the `BLECharacteristic(const char* uuid, unsigned char properties, const char* value)` constructor path.