### PR TITLE
Make sure LED is not lit on sketch start

### DIFF
--- a/variants/arduino_101/variant.cpp
+++ b/variants/arduino_101/variant.cpp
@@ -180,6 +180,8 @@ void variantGpioInit(void)
         SET_PIN_MODE(p->ulSocPin, p->ulPinMode);
         pinmuxMode[pin] = GPIO_MUX_MODE;
     }
+    //make sure the led is not lit on sketch start
+    digitalWrite(LED_BUILTIN, LOW);
 }
 
 void variantPwmInit(void)


### PR DESCRIPTION
-The LED retains the last state it was in after a sketch upload
-We need to make sure its is not lit on sketch startup so that behavior
is consistent