### PR TITLE
Jira 890, Allow BLE Descriptor reading to be blocking, git 478

### DIFF
--- a/libraries/CurieBLE/src/internal/BLEDescriptorImp.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDescriptorImp.cpp
@@ -172,6 +172,7 @@ bool BLEDescriptorImp::read()
 {
     int retval = 0;
     bt_conn_t* conn = NULL;
+    bool ret_bool = true;
     
     if (true == BLEUtils::isLocalBLE(_bledev))
     {
@@ -209,6 +210,13 @@ bool BLEDescriptorImp::read()
     {
         _reading = true;
     }
+    
+    // Block the read
+    while (_reading == true && ret_bool)
+    {
+        delay(5);
+        ret_bool = _bledev.connected();
+    }
     return _reading;
 }
 
@@ -219,6 +227,12 @@ bool BLEDescriptorImp::writeValue(const byte value[],
     bool ret = true;
     int total_length = length + offset;
     int write_len = length;
+    
+    if (_reading)
+    {
+        _reading = false;
+    }
+    
     if (total_length > BLE_MAX_ATTR_DATA_LEN)
     {
         return false;


### PR DESCRIPTION
Feature requested:
  To make the reading of the Descriptor of a BLE Characteristic a blocking read method.  The mechanism is similar to the the Characteristic read method.  However, for Descriptor read(), it is always a blocking read.

Code Mods:
1.  libraries/CurieBLE/src/internal/BLEDescriptorImp.cpp:
     -  Added a flag for the Descriptor read completion event to set in foreground.
     -  Check on the Descriptor read completion event in the background as an exit condition for the read method.
