### PR TITLE
Jira 896, BLE scan withDuplicates logic inversion, git 476

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -247,14 +247,8 @@ bool BLEDevice::startScan(bool withDuplicates)
     }
     else
     {
-        return BLEDeviceManager::instance()->startScanning();
+        return BLEDeviceManager::instance()->startScanningNewPeripherals();
     }
-}
-
-
-void BLEDevice::scan()
-{
-    scan(false);
 }
 
 void BLEDevice::scan(bool withDuplicates)
@@ -263,20 +257,10 @@ void BLEDevice::scan(bool withDuplicates)
     startScan(withDuplicates);
 }
 
-void BLEDevice::scanForName(String name)
-{
-    scanForName(name, false);
-}
-
 void BLEDevice::scanForName(String name, bool withDuplicates)
 {
     BLEDeviceManager::instance()->setAdvertiseCritical(name);
     startScan(withDuplicates);
-}
-
-void BLEDevice::scanForUuid(String uuid)
-{
-    scanForUuid(uuid, false);
 }
 
 void BLEDevice::scanForUuid(String uuid, bool withDuplicates)

--- a/libraries/CurieBLE/src/BLEDevice.h
+++ b/libraries/CurieBLE/src/BLEDevice.h
@@ -361,83 +361,78 @@ class BLEDevice
     //void scanForAddress(String address); // Not include in baseline. Add here as feature for feature release.
     
     /**
-     * @brief   Start scanning for peripherals without filter
+     * @brief   Start scanning for peripherals with the option of accepting all detectable
+     *          Peripherals or just the newly detected.
      *
-     * @param   none
-     *
-     * @return  none
-     *
-     * @note  none
-     */
-    void scan();
-    
-    /**
-     * @brief   Start scanning for peripherals with filter
-     *
-     * @param[in] withDuplicates        true - with duplicate filter
-     *                                  false- without duplicate filter
+     * @param[in] withDuplicates        true - return all detectable Peripherals.
+     *                                  false- return a detected Peripheral only once.
      *
      * @return  none
      *
-     * @note  option to filter out duplicate addresses for Arduino.
-     *          The current only support fileter duplicate mode.
+     * @note  When, withDuplicates = true, accept all detectable Peripherals.
+     *        No Peripheral filtering process applied to the scan result.
+     *        By default, withDuplicates = false, a detected Peripheral is
+     *        reported once.
      */
-    void scan(bool withDuplicates);
+    void scan(bool withDuplicates = false);
     
     /**
-     * @brief   Start scanning for peripherals and filter by device name in ADV
-     *
-     * @param   name    The device's local name.
-     *
-     * @return  none
-     *
-     * @note   option to filter out duplicate addresses for Arduino.
-     *          The current only support fileter duplicate mode.
-     */
-    void scanForName(String name);
-    
-    /**
-     * @brief   Start scanning for peripherals and filter by device name in ADV
+     * @brief   Start scanning for peripherals and filter by device name in ADV and
+     *          the option of accepting all detectable Peripherals or just the
+     *          newly detected.
      *
      * @param[in]   name    The device's local name.
      *
-     * @param[in]   withDuplicates      true - with duplicate filter
-     *                                  false- without duplicate filter
+     * @param[in]   withDuplicates      true - return all detectable Peripherals.
+     *                                  false- return a detected Peripheral only once.
      *
      * @return  none
      *
-     * @note   option to filter out duplicate addresses for Arduino.
-     *          The current only support fileter duplicate mode.
+     * @note  When, withDuplicates = true, accept all detectable Peripherals.
+     *        No Peripheral filtering process applied to the scan result.
+     *        By default, withDuplicates = false, a detected Peripheral is
+     *        reported once.
      */
-    void scanForName(String name, bool withDuplicates);
+    void scanForName(String name, bool withDuplicates = false);
     
     /**
-     * @brief   Start scanning for peripherals and filter by service in ADV
-     *
-     * @param   service    The service
-     *
-     * @return  none
-     *
-     * @note  none
-     */
-    void scanForUuid(String uuid);
-    
-    /**
-     * @brief   Start scanning for peripherals and filter by service in ADV
+     * @brief   Start scanning for peripherals and filter by service in ADV and
+     *          the option of accepting all detectable Peripherals or just the
+     *          newly detected.
      *
      * @param[in]   service    The service
      *
-     * @param[in]   withDuplicates      true - with duplicate filter
-     *                                  false- without duplicate filter
+     * @param[in]   withDuplicates      true - return all detectable Peripherals.
+     *                                  false- return a detected Peripheral only once.
      *
      * @return  none
      *
-     * @note   option to filter out duplicate addresses for Arduino.
-     *          The current only support fileter duplicate mode.
+     * @note   When, withDuplicates = true, accept all detectable Peripherals.
+     *         No Peripheral filtering process applied to the scan result.
+     *         By default, withDuplicates = false, a detected Peripheral is
+     *         reported once.
      */
-    void scanForUuid(String uuid, bool withDuplicates);
+    void scanForUuid(String uuid, bool withDuplicates = false);
     
-    void scanForAddress(String macaddr, bool withDuplicates = true);
+    /**
+     * @brief   Start scanning for peripherals and filter by MAC address and
+     *          the option of accepting all detectable Peripherals or just the
+     *          newly detected.
+     *
+     * @param[in]   macaddr     The Peripheral MAC address
+     *
+     * @param[in]   withDuplicates      true - return all detectable Peripherals.
+     *                                  false- return a detected Peripheral only once.
+     *
+     * @return  none
+     *
+     * @note   When, withDuplicates = true, accept all detectable Peripherals.
+     *         No Peripheral filtering process applied to the scan result.
+     *         By default, withDuplicates = false, a detected Peripheral is
+     *         reported once.
+     */
+    void scanForAddress(String macaddr, bool withDuplicates = false);
+
     /**
      * @brief   Stop scanning for peripherals
      *
@@ -679,15 +674,15 @@ private:
     void preCheckProfile();
     
     /**
-     * @brief   Start scanning for peripherals with/without duplicate filter
+     * @brief   Start scanning for peripherals with the option of accepting all
+     *          detectable Peripherals or just the newly detected.
      *
-     * @param[in] withDuplicates        true - with duplicate filter
-     *                                  false- without duplicate filter
+     * @param[in] withDuplicates        true - return all detectable Peripherals.
+     *                                  false- return a detected Peripheral only once.
      *
      * @return  none
      *
-     * @note  option to filter out duplicate addresses for Arduino.
-     *          The current only support fileter duplicate mode.
+     * @note  When, withDuplicates = true, accept all detectable Peripherals.
      */
     bool startScan(bool withDuplicates);
     

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -593,7 +593,7 @@ void BLEDeviceManager::_clearAdvertiseBuffer()
     
 }
 
-bool BLEDeviceManager::startScanning()
+bool BLEDeviceManager::startScanningWithDuplicates()
 {
     _adv_duplicate_filter_enabled = false;
     _scan_param.filter_dup   = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE;
@@ -609,7 +609,7 @@ bool BLEDeviceManager::startScanning()
     return true;
 }
 
-bool BLEDeviceManager::startScanningWithDuplicates()
+bool BLEDeviceManager::startScanningNewPeripherals()
 {
     _adv_duplicate_filter_enabled = true;
     memset(_peer_duplicate_address_buffer, 0, sizeof(_peer_duplicate_address_buffer));
@@ -1096,8 +1096,8 @@ bool BLEDeviceManager::connect(BLEDevice &device)
     _wait_for_connect_peripheral_adv_data_len = _available_for_connect_peripheral_adv_data_len;
     _wait_for_connect_peripheral_scan_rsp_data_len = _available_for_connect_peripheral_scan_rsp_data_len;
     _wait_for_connect_peripheral_adv_rssi = _available_for_connect_peripheral_adv_rssi;
-            
-    startScanning();
+
+    startScanningWithDuplicates();
     
     pr_debug(LOG_MODULE_BLE, "%s-%d", __FUNCTION__, __LINE__);
     // Wait for the connection

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -310,7 +310,7 @@ class BLEDeviceManager
     void setAdvertiseCritical(String name);
     void setAdvertiseCritical(BLEService& service);
     void setAdvertiseCritical(const char* macaddress);
-    bool startScanning(); // start scanning for peripherals
+    bool startScanningNewPeripherals(); // start scanning for new peripherals, don't report the detected ones
     bool startScanningWithDuplicates(); // start scanning for peripherals, and report all duplicates
     bool stopScanning(); // stop scanning for peripherals
     


### PR DESCRIPTION
Bug fixed:
  This feature was implemented in PR #457, merged, and released
in Deneb.RC1.  However, it was discovered that the logic was
inverted and was report as Git issue #476.  BLE scan() and
input parameter withDuplicates is true means reporting all
Peripherals detected regardless how many times it was reported.

Code mods:
1.  libraries/CurieBLE/src/BLEDevice.cpp:
    - In startScan, calls the correct routine to scan for all
      Peripherals if withDuplicates is true.  Otherwise,
      just scan for new ones.
2.  libraries/CurieBLE/src/BLEDevice.h:
    - Prototyping.
3.  libraries/CurieBLE/src/internal/BLEDeviceManager.h,
    libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
    - Modified header comment to reflect the input parameter
      withDuplictes correct meaning.
    - Default the input parameter, withDupilcates, as true.
    - And, consequently, eliminated some redundant methods.