### PR TITLE
Fix Jira 768 BLE Appearance Value is 0

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -178,7 +178,11 @@ void BLEDevice::setDeviceName(const char* deviceName)
 
 void BLEDevice::setAppearance(unsigned short appearance)
 {
-    BLEDeviceManager::instance()->setAppearance(appearance);
+    if (BLEUtils::isLocalBLE(*this))
+    {
+        // Only local device can set the appearance
+        BLEDeviceManager::instance()->setAppearance(appearance);
+    }
 }
 
 int BLEDevice::addService(BLEService& attribute)

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -45,7 +45,6 @@ BLEDeviceManager::BLEDeviceManager():
     _connecting(false),
     _has_service_uuid(false),
     _has_service_solicit_uuid(false),
-    _appearance(0),
     _manufacturer_data_length(0),
     _service_data_length(0),
     _adv_type(0),
@@ -337,7 +336,7 @@ BLEDeviceManager::setDeviceName()
 
 void BLEDeviceManager::setAppearance(unsigned short appearance)
 {
-    _appearance = appearance;
+    BLEProfileManager::instance()->setAppearance(appearance);
 }
 
 BLE_STATUS_T
@@ -1028,7 +1027,7 @@ String BLEDeviceManager::advertisedServiceUuid(const BLEDevice* device, int inde
         if (index < service_cnt)
         {
             if (type == BT_DATA_UUID16_ALL ||
-		type == BT_DATA_UUID16_SOME)
+                type == BT_DATA_UUID16_SOME)
             {
                 service_uuid.uuid.type = BT_UUID_TYPE_16;
                 memcpy(&BT_UUID_16(&service_uuid.uuid)->val, &adv_data[2], 2);
@@ -1200,7 +1199,7 @@ String BLEDeviceManager::deviceName(const BLEDevice* device)
 
 int BLEDeviceManager::appearance()
 {
-    return _appearance;
+    return BLEProfileManager::instance()->getAppearance();
 }
 
 BLEDeviceManager* BLEDeviceManager::instance()
@@ -1301,12 +1300,6 @@ bool BLEDeviceManager::advertiseDataProc(uint8_t type,
                                          const uint8_t *dataPtr, 
                                          uint8_t data_len)
 {
-    //Serial1.print("[AD]:");
-    //Serial1.print(type);
-    //Serial1.print(" data_len ");
-    //Serial1.println(data_len);
-    
-    //const bt_data_t zero = {0, 0,0};
     if (_adv_accept_critical.type == 0 && 
         _adv_accept_critical.data_len == 0 &&
         _adv_accept_critical.data == NULL)
@@ -1314,6 +1307,7 @@ bool BLEDeviceManager::advertiseDataProc(uint8_t type,
         // Not set the critical. Accept all.
         return true;
     }
+    
     if (type == _adv_accept_critical.type &&
         data_len == _adv_accept_critical.data_len &&
         0 == memcmp(dataPtr, _adv_accept_critical.data, data_len))

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -448,7 +448,6 @@ private:
     bt_uuid_128_t _service_uuid;
     bool _has_service_solicit_uuid;
     bt_uuid_128_t _service_solicit_uuid;
-    uint16_t   _appearance;
     uint8_t    _manufacturer_data[BLE_MAX_ADV_SIZE];
     uint8_t    _manufacturer_data_length;
     bt_uuid_128_t _service_data_uuid;

--- a/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEProfileManager.cpp
@@ -26,6 +26,8 @@
 #include "BLEUtils.h"
 
 BLEDevice BLE(BLEUtils::bleGetLoalAddress());
+static BLEService gapService("1800");
+static BLEUnsignedShortCharacteristic appearenceChrc("2a01", BLERead);
 
 BLEProfileManager* BLEProfileManager::_instance = NULL;
 
@@ -67,6 +69,8 @@ BLEProfileManager::BLEProfileManager ():
         _service_header_array[i].value = NULL;
     }
     
+    addService(BLE, gapService);
+    gapService.addCharacteristic(appearenceChrc);
     pr_debug(LOG_MODULE_BLE, "%s-%d: Construct", __FUNCTION__, __LINE__);
 }
 
@@ -1130,5 +1134,16 @@ uint8_t BLEProfileManager::serviceReadRspProc(bt_conn_t *conn,
     return BT_GATT_ITER_STOP;
 }
 
+void BLEProfileManager::setAppearance(unsigned short appearance)
+{
+    if (false == hasRegisterProfile())
+    {
+        appearenceChrc.setValue(appearance);
+    }
+}
 
+unsigned short BLEProfileManager::getAppearance()
+{
+    return appearenceChrc.value();
+}
 

--- a/libraries/CurieBLE/src/internal/BLEProfileManager.h
+++ b/libraries/CurieBLE/src/internal/BLEProfileManager.h
@@ -117,6 +117,20 @@ public:
                                bt_gatt_read_params_t *params,
                                const void *data, 
                                uint16_t length);
+    /**
+     * @brief   Set the appearance type for the BLE Peripheral Device
+     *
+     * See https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml
+     * for available options.
+     *
+     * @param[in] appearance Appearance category identifier as defined by BLE Standard
+     *
+     * @return BleStatus indicating success or error
+     *
+     * @note This method must be called before the begin method
+     */
+    void setAppearance(unsigned short appearance);
+    unsigned short getAppearance();
 protected:
     friend ssize_t profile_write_process(bt_conn_t *conn,
                                      const bt_gatt_attr_t *attr,


### PR DESCRIPTION
Fix issue #367 
Solution:
  Add service and appearance characteristic in the BLE lib.

Changed files
  BLEDevice.cpp - check the local device
  BLEDeviceManager.cpp - Change the calls
  BLEDeviceManager.h - remove appearance member
  BLEProfileManager.cpp - Add GAP service and appearance characteristic
  BLEProfileManager.h - Add set/get API