### PR TITLE
Fix Jira 864 After BLE.end() a peripheral is still showing up in scans

### DIFF
--- a/libraries/CurieBLE/src/BLEDevice.cpp
+++ b/libraries/CurieBLE/src/BLEDevice.cpp
@@ -82,7 +82,12 @@ void BLEDevice::poll()
 }
 
 void BLEDevice::end()
-{}
+{
+    if (BLEUtils::isLocalBLE(*this))
+    {
+        BLEDeviceManager::instance()->end();
+    }
+}
 
 bool BLEDevice::connected() const
 {

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -167,6 +167,10 @@ void BLEDeviceManager::poll()
 
 void BLEDeviceManager::end()
 {
+    stopScanning();
+    stopAdvertising();
+    // Disconnect the connections
+    disconnect(&BLE);
 }
 
 bool BLEDeviceManager::connected(const BLEDevice *device) const


### PR DESCRIPTION
Also fixed Jira 839
1. Stop scan, advertising and disconnect the connected devices when call end

Changed files
BLEDeviceManager.cpp - do the real action
BLEDevice.cpp - only local BLE device call the real end