### PR TITLE
Remove comment about BatteryMonitor_Central sketch

### DIFF
--- a/libraries/CurieBLE/examples/peripheral/BatteryMonitor/BatteryMonitor.ino
+++ b/libraries/CurieBLE/examples/peripheral/BatteryMonitor/BatteryMonitor.ino
@@ -38,7 +38,6 @@ void setup() {
      This name will appear in advertising packets
      and can be used by remote devices to identify this BLE device
      The name can be changed but maybe be truncated based on space left in advertisement packet
-     If you want to make this work with the BatteryMonitor_Central sketch, do not modufy the name.
   */
   BLE.setLocalName("BatteryMonitor");
   BLE.setAdvertisedService(batteryService);  // add the service UUID


### PR DESCRIPTION
As it has been moved to the test folder for now as part of #375. I forgot to remove this comment.

@SidLeung please make sure this change is included in Deneb.