### PR TITLE
Wait for scan response before reporting discovered peripheral

### DIFF
--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -81,7 +81,7 @@ BLEDeviceManager::BLEDeviceManager():
     memset(_peer_adv_data, 0, sizeof(_peer_adv_data));
     memset(_peer_adv_data_len, 0, sizeof(_peer_adv_data_len));
     memset(_peer_scan_rsp_data, 0, sizeof(_peer_scan_rsp_data));
-    memset(_peer_scan_rsp_data_len, 0, sizeof(_peer_scan_rsp_data_len));
+    memset(_peer_scan_rsp_data_len, -1, sizeof(_peer_scan_rsp_data_len));
     memset(_peer_adv_rssi, 0, sizeof(_peer_adv_rssi));
     
     memset(_peer_adv_connectable, 0, sizeof(_peer_adv_connectable));
@@ -1370,7 +1370,7 @@ BLEDevice BLEDeviceManager::available()
     {
         uint64_t timestamp_delta = timestamp - _peer_adv_mill[i];
         temp = &_peer_adv_buffer[i];
-        if ((timestamp_delta <= 2000) && (max_delta < timestamp_delta))
+        if ((timestamp_delta <= 2000) && (max_delta < timestamp_delta) && (_peer_scan_rsp_data_len[i] >= 0 || !_peer_adv_connectable[i]))
         {
             // Eable the duplicate filter
             if (_adv_duplicate_filter_enabled && 
@@ -1432,7 +1432,7 @@ bool BLEDeviceManager::setAdvertiseBuffer(const bt_addr_le_t* bt_addr,
             if (max_delta > 2000) // expired
             {
                 index = i;
-                _peer_scan_rsp_data_len[index] = 0; // Invalid the scan response
+                _peer_scan_rsp_data_len[index] = -1; // Invalid the scan response
             }
         }
         

--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.h
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.h
@@ -409,7 +409,7 @@ private:
     uint8_t    _peer_adv_data[BLE_MAX_ADV_BUFFER_CFG][BLE_MAX_ADV_SIZE];
     uint8_t    _peer_adv_data_len[BLE_MAX_ADV_BUFFER_CFG];
     uint8_t    _peer_scan_rsp_data[BLE_MAX_ADV_BUFFER_CFG][BLE_MAX_ADV_SIZE];
-    uint8_t    _peer_scan_rsp_data_len[BLE_MAX_ADV_BUFFER_CFG];
+    int8_t     _peer_scan_rsp_data_len[BLE_MAX_ADV_BUFFER_CFG];
     int8_t     _peer_adv_rssi[BLE_MAX_ADV_BUFFER_CFG];
     bool       _peer_adv_connectable[BLE_MAX_ADV_BUFFER_CFG];
     


### PR DESCRIPTION
This change waits for a scan response from the peripheral before reporting it to the user.

This is a proposal to fix https://github.com/01org/corelibs-arduino101/issues/497 and https://github.com/01org/corelibs-arduino101/issues/370#issuecomment-289112547.

The downside is that devices that don't respond to scan responses will be ignored.

@SidLeung please consider this for the Deneb release.