### PR TITLE
Added missing keyword

### DIFF
--- a/libraries/CurieBLE/keywords.txt
+++ b/libraries/CurieBLE/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-
+CurieBLE    KEYWORD1
 BLEAttributeWithValue	KEYWORD1
 BLEBoolCharacteristic	KEYWORD1
 BLEByteCharacteristic	KEYWORD1


### PR DESCRIPTION
In this way CurieBLE is highlighted as all the Arduino .h are