### PR TITLE
Fix GIT #516 and 517 return success when respond with error

### DIFF
--- a/libraries/CurieBLE/src/internal/BLECallbacks.cpp
+++ b/libraries/CurieBLE/src/internal/BLECallbacks.cpp
@@ -157,10 +157,6 @@ uint8_t profile_read_rsp_process(bt_conn_t *conn,
                                  const void *data, 
                                  uint16_t length)
 {
-    if (NULL == data && 0 != length)
-    {
-        return BT_GATT_ITER_STOP;
-    }
     BLECharacteristicImp *chrc = NULL;
     BLEDevice bleDevice(bt_conn_get_dst(conn));
     

--- a/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
+++ b/libraries/CurieBLE/src/internal/BLECharacteristicImp.h
@@ -331,7 +331,10 @@ private:
     bool        _subscribed;
     
     volatile bool _reading;
+    volatile bool _gattc_read_result;
+    
     static volatile bool _gattc_writing;
+    static volatile bool _gattc_write_result;
     bt_gatt_read_params_t _read_params; // GATT read parameter
     
     typedef LinkNode<BLEDescriptorImp *>  BLEDescriptorLinkNodeHeader;


### PR DESCRIPTION
Root cause
1. The return value indecate the read/write request send successfully.
2. The subscribe will ignore the response and this will not be fixed.

Solution
1. Add the error detect based on read/write response.

Changed files
BLECallbacks.cpp - Delete the error check for read response.
BLECharacteristicImp.cpp
  - Add the error check.
  - Optimize the memory allocate and clear the allocated memory.
BLECharacteristicImp.h - Add varibles to flag the response error