### PR TITLE
Fix compile rules for paths with spaces

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -71,7 +71,7 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" "-L{build.variant.path}" -Wl,--whole-archive "-l{build.variant_system_lib}" -Wl,--no-whole-archive -Wl,--start-group "-l{build.variant_system_lib}" -lnsim -lc -lm -lgcc {object_files} "{build.path}/{archive_file}"
 
 ## Save output with debug symbols (.debug.elf file). Uncomment if you wish to use OpenOCD to debug.
-recipe.hooks.objcopy.preobjcopy.1.pattern={runtime.tools.arduino101load.path}/arduino101load -c -from="{build.path}/{build.project_name}.elf" -to="{build.path}/../arduino101_sketch.debug.elf"
+recipe.hooks.objcopy.preobjcopy.1.pattern="{runtime.tools.arduino101load.path}/arduino101load" -c -from="{build.path}/{build.project_name}.elf" -to="{build.path}/../arduino101_sketch.debug.elf"
 
 ## Create output (.bin file)
 recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2bin.cmd}" {compiler.elf2bin.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"
@@ -107,7 +107,7 @@ tools.arduino101load.cmd.path={runtime.tools.arduino101load.path}/arduino101load
 tools.arduino101load.upload.params.verbose=-v
 tools.arduino101load.upload.params.quiet=-q
 
-tools.arduino101load.upload.pattern="{cmd.path}" -dfu="{runtime.tools.dfu-util.path}" -bin="{build.path}/{build.project_name}.bin" -port={serial.port} "{upload.verbose}" -ble_fw_str={ble.fw.string} -ble_fw_pos={ble.fw.position} -rtos_fw_str={rtos.fw.string} -rtos_fw_pos={rtos.fw.position} -core={version}
+tools.arduino101load.upload.pattern="{cmd.path}" "-dfu={runtime.tools.dfu-util.path}" "-bin={build.path}/{build.project_name}.bin" -port={serial.port} "{upload.verbose}" -ble_fw_str={ble.fw.string} -ble_fw_pos={ble.fw.position} -rtos_fw_str={rtos.fw.string} -rtos_fw_pos={rtos.fw.position} -core={version}
 
 # This is needed to avoid an error on unexistent fields
 tools.arduino101load.erase.params.verbose=
@@ -115,4 +115,4 @@ tools.arduino101load.erase.params.quiet=
 tools.arduino101load.erase.pattern=
 tools.arduino101load.bootloader.params.verbose=-v
 tools.arduino101load.bootloader.params.quiet=-q
-tools.arduino101load.bootloader.pattern="{cmd.path}" -dfu="{runtime.tools.dfu-util.path}"  -port={serial.port} "{bootloader.verbose}" -f -core={version}
+tools.arduino101load.bootloader.pattern="{cmd.path}" "-dfu={runtime.tools.dfu-util.path}"  -port={serial.port} "{bootloader.verbose}" -f -core={version}

--- a/variants/arduino_101/linker_scripts/flash.ld
+++ b/variants/arduino_101/linker_scripts/flash.ld
@@ -40,7 +40,7 @@ OUTPUT_FORMAT("elf32-littlearc", "elf32-bigarc", "elf32-littlearc")
 MEMORY
     {
     FLASH                 (rx) : ORIGIN = 0x40034000, LENGTH = 152K
-    SRAM                  (wx) : ORIGIN = 0xa800e000, LENGTH = 24K
+    SRAM                  (wx) : ORIGIN = 0xa800a000, LENGTH = 40K
     DCCM                  (wx) : ORIGIN = 0x80000000, LENGTH = 8K
     }
 
@@ -52,7 +52,7 @@ __firq_stack_size = 1024;
 
 /* Minimum heap size to allocate
  * Actual heap size might be bigger due to page size alignment */
-__HEAP_SIZE_MIN = 8192;
+__HEAP_SIZE_MIN = 16384;
 /* This should be set to the page size used by the malloc implementation */
 __PAGE_SIZE = 4096;
 


### PR DESCRIPTION
The Java IDE applies specific transformations to the input "recipes" based on locale and OS. On Windows, if a path contains a space, the quotation marks get ignored and the whole commandline gets passed to the underlying GO program as a single string, leading to a failure when calling `flag.Parse` . Enclosing the whole flag+path instead than the path alone fixes the issue.