### PR TITLE
Correct value of BLE.connected()

### DIFF
--- a/libraries/CurieBLE/src/BLEPeripheral.cpp
+++ b/libraries/CurieBLE/src/BLEPeripheral.cpp
@@ -146,8 +146,7 @@ BLECentral BLEPeripheral::central(void)
 
 bool BLEPeripheral::connected(void)
 {
-    BLEDevice centralBle = BLE.central();
-    return centralBle.connected();
+    return BLE.connected();
 }
 
 void BLEPeripheral::init()


### PR DESCRIPTION
As discussed in #507.

Now it will check:
- if in peripheral mode and if a central is connected
- if in central mode and if a peripheral is connected

I've also reverted https://github.com/01org/corelibs-arduino101/commit/a2df1795ac275ac48485329dc0697ab2324715bf from PR #454 as the change it no longer required with https://github.com/01org/corelibs-arduino101/commit/58c323e278a510e6e6ec2d0c4f29de69a0c11384.

cc/ @jimaobian