### PR TITLE
stdlib_noniso.cpp: fix another rounding error in dtostrf

### DIFF
--- a/cores/arduino/stdlib_noniso.cpp
+++ b/cores/arduino/stdlib_noniso.cpp
@@ -199,6 +199,12 @@ char *dtostrf(double number, signed char width, unsigned char prec, char *s)
         return s;
     }
 
+    // rounding up to the precision
+    rounding = 0.5;
+    for (i = 0; i < prec; ++i)
+        rounding /= 10.0;
+    number += rounding;
+
     out = s;
     before = digitsBe4Decimal(number);
 
@@ -214,12 +220,6 @@ char *dtostrf(double number, signed char width, unsigned char prec, char *s)
       *out = '-';
       number = -number;
     }
-
-    // rounding up to the precision
-    rounding = 0.5;
-    for (i = 0; i < prec; ++i)
-        rounding /= 10.0;
-    number += rounding;
 
     // seperate integral and fractional parts
     integer = (unsigned long long) number;


### PR DESCRIPTION
This is a nasty one. Rounding up the passed float/double to the specified presicion must be the
*very first* thing we do, before doing anything else with that value
(In this case, the issue was cause by digitsBe4Decimal() returning an
incorrect value, because it was being called before passed value was
rounded up).

The result of this error can be seen by attempting to print a float/double value which equals **any power of 10, minus 0.001**, for example 9.999, 99.999, 999.999, etc. Before this commit, calls to Serial.print with such a value will hang indefinitely.