### PR TITLE
stdlib_noniso.cpp: dtostrf(), subtract rounding if number is negative

### DIFF
--- a/cores/arduino/stdlib_noniso.cpp
+++ b/cores/arduino/stdlib_noniso.cpp
@@ -203,7 +203,11 @@ char *dtostrf(double number, signed char width, unsigned char prec, char *s)
     rounding = 0.5;
     for (i = 0; i < prec; ++i)
         rounding /= 10.0;
-    number += rounding;
+
+    if (number < 0.0)
+        number -= rounding;
+    else
+        number += rounding;
 
     out = s;
     before = digitsBe4Decimal(number);
@@ -235,17 +239,17 @@ char *dtostrf(double number, signed char width, unsigned char prec, char *s)
 
     out[i - 1] = ASCII_ZERO + integer;
     out += before;
-    if (!prec) goto end;
 
-    // generate chars for each digit of the fractional part
-    *out++ = '.';
-    for (i = 0; i < prec; ++i) {
-        fraction *= 10.0;
-        digit = ((unsigned long long) fraction) % 10;
-        *out++ = (char) (ASCII_ZERO + digit);
+    if (prec) {
+        // generate chars for each digit of the fractional part
+        *out++ = '.';
+        for (i = 0; i < prec; ++i) {
+            fraction *= 10.0;
+            digit = ((unsigned long long) fraction) % 10;
+            *out++ = (char) (ASCII_ZERO + digit);
+        }
     }
 
-end:
     // check if padding is required
     if (width > 0) {
         delta = width - (before + prec + 1);


### PR DESCRIPTION
If we are working with a negative number, then *adding* the rounding
onto the number has the opposite to the intended effect. Need to check
if the number is negative, and if so, subtract the rounding instead of
adding.

It may appear that a cleaner solution to this is to simply move the
"handle negative numbers" block (starting on what is now line 222)
before the "round up to the precision" block (starting on what is now
line 202). However, I don't think this will work without a substantial
re-design of this function, for the following reasons;

Any leading padding must be added before handling a negative number
(adding the '-' char. to output, and then flipping the number's sign for
calculations). And in order to add the right amount of padding, we must run
digitsBe4Decimal first, and in order to guarantee an accurate result
from *that*, the rounding-up must have been done. So there's a fairly
rigid order here.

Oh, and I also removed the 'goto end', and the label, since an if()
work just as well. Can't remember why I even added that in the first
place.