### PR TITLE
CurieBLE: Correct EIR length calculations

### DIFF
--- a/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
+++ b/libraries/CurieBLE/src/internal/BLEDeviceManager.cpp
@@ -369,17 +369,16 @@ BLEDeviceManager::setAdvertiseData(uint8_t type, const uint8_t* data, uint8_t le
     
     for (uint8_t i = 0; i < _scan_rsp_data_idx; i++)
     {
-        lengthOfAdv += _scan_rsp_data[i].data_len + 2;
-    }
+        lengthOfScanRsp += _scan_rsp_data[i].data_len + 2;
+    }   
         
-        
-    if (((length + lengthOfAdv) < BLE_MAX_ADV_SIZE) && 
+    if (((length + 2 + lengthOfAdv) <= BLE_MAX_ADV_SIZE) && 
         (_adv_data_idx < ARRAY_SIZE(_adv_data)))
     {
         fill_area = &_adv_data[_adv_data_idx];
         _adv_data_idx++;
     }
-    else if ((length + lengthOfScanRsp) < BLE_MAX_ADV_SIZE && 
+    else if ((length + 2 + lengthOfScanRsp) <= BLE_MAX_ADV_SIZE && 
              (_scan_rsp_data_idx < ARRAY_SIZE(_scan_rsp_data)))
     {
         fill_area = &_scan_rsp_data[_scan_rsp_data_idx];


### PR DESCRIPTION
Fixes #543.

Corrects two things:

1) `lengthOfScanRsp` was never updated
2) Space calculations where not taking EIR header length (2 bytes) into account

@SidLeung please consider this change for Elnath, if it is too late for Bootes.

cc/ @CarlaMSedze @rodriguezcarlos