### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/libraries/CurieBLE/keywords.txt
+++ b/libraries/CurieBLE/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-CurieBLE    KEYWORD1
+CurieBLE	KEYWORD1
 BLEAttributeWithValue	KEYWORD1
 BLEBoolCharacteristic	KEYWORD1
 BLEByteCharacteristic	KEYWORD1

--- a/libraries/CurieIMU/keywords.txt
+++ b/libraries/CurieIMU/keywords.txt
@@ -14,7 +14,7 @@ CurieIMUClass	KEYWORD1
 
 begin	KEYWORD1
 
-dataReady   KEYWORD1
+dataReady	KEYWORD1
 getGyroRate	KEYWORD1
 setGyroRate	KEYWORD1
 getAccelerometerRate	KEYWORD1
@@ -65,7 +65,7 @@ readAcceleration	KEYWORD1
 readRotation	KEYWORD1
 
 readAccelerometer	KEYWORD1
-readAccelerometerScaled KEYWORD1
+readAccelerometerScaled	KEYWORD1
 readGyro	KEYWORD1
 readGyroScaled	KEYWORD1
 readTemperature	KEYWORD1
@@ -85,8 +85,8 @@ CurieIMU	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-ACCEL   LITERAL1
-GYRO    LITERAL1
+ACCEL	LITERAL1
+GYRO	LITERAL1
 
 X_AXIS	LITERAL1
 Y_AXIS	LITERAL1

--- a/libraries/CuriePowerManagement/keywords.txt
+++ b/libraries/CuriePowerManagement/keywords.txt
@@ -11,7 +11,7 @@
 #######################################
 sleep	KEYWORD2
 deepSleep	KEYWORD2
-idle    KEYWORD2
+idle	KEYWORD2
 doze	KEYWORD2
 wakeFromDoze	KEYWORD2
 

--- a/libraries/CurieTimerOne/keywords.txt
+++ b/libraries/CurieTimerOne/keywords.txt
@@ -6,29 +6,29 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CurieTimer KEYWORD1
+CurieTimer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-initialize      KEYWORD2
-setPeriod       KEYWORD2
-start           KEYWORD2
-stop            KEYWORD2
-restart         KEYWORD2
-resume          KEYWORD2
-setPwmDuty      KEYWORD2
-pwm             KEYWORD2
-disablePwm      KEYWORD2
-attachInterrupt KEYWORD2
-detachInterrupt KEYWORD2
-kill            KEYWORD2
-readTickCount   KEYWORD2
-rdRstTickCount  KEYWORD2
-pause           KEYWORD2
-pwmStart        KEYWORD2
-pwmStop         KEYWORD2
+initialize	KEYWORD2
+setPeriod	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+restart	KEYWORD2
+resume	KEYWORD2
+setPwmDuty	KEYWORD2
+pwm	KEYWORD2
+disablePwm	KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
+kill	KEYWORD2
+readTickCount	KEYWORD2
+rdRstTickCount	KEYWORD2
+pause	KEYWORD2
+pwmStart	KEYWORD2
+pwmStop	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################
-CurieTimerOne   KEYWORD2
+CurieTimerOne	KEYWORD2

--- a/libraries/SPI/keywords.txt
+++ b/libraries/SPI/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 SPI	KEYWORD1
-SPI1    KEYWORD1
+SPI1	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords