### PR TITLE
Set a baud rate limit for cdc-acm internally

### DIFF
--- a/cores/arduino/CDCSerialClass.cpp
+++ b/cores/arduino/CDCSerialClass.cpp
@@ -86,8 +86,13 @@ void CDCSerialClass::begin(const uint32_t dwBaudRate, const uint8_t config)
 }
 
 
-void CDCSerialClass::init(const uint32_t dwBaudRate, const uint8_t modeReg)
+void CDCSerialClass::init(uint32_t dwBaudRate, const uint8_t modeReg)
 {
+    /* Set a max internal baud rate due to the limitation of the 
+     * Inter Processor Mailbox */
+     if(dwBaudRate > 115200)
+         dwBaudRate = 115200;
+    
     /* Set a per-byte write delay approximately equal to the time it would
      * take to clock out a byte on a standard UART at this baud rate */
     _writeDelayUsec = 8000000 / dwBaudRate;

--- a/cores/arduino/CDCSerialClass.h
+++ b/cores/arduino/CDCSerialClass.h
@@ -63,7 +63,7 @@ class CDCSerialClass : public HardwareSerial
     };
 
   protected:
-    void init(const uint32_t dwBaudRate, const uint8_t config);
+    void init(uint32_t dwBaudRate, const uint8_t config);
 
     uart_init_info *info;
     uint32_t _writeDelayUsec;


### PR DESCRIPTION
-set a baud rate limit for cdc-acm due to the limitation of Inter Processor Mailbox