### PR TITLE
move extra_flags into flags

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -14,12 +14,12 @@ compiler.prefix=arc-elf32
 
 compiler.path={runtime.tools.arc-elf32.path}/bin/
 compiler.c.cmd=arc-elf32-gcc
-compiler.c.flags=-c -std=gnu11 -mcpu=quarkse_em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -fsigned-char -MMD -D__ARDUINO_ARC__ -DCONFIG_BLUETOOTH_PERIPHERAL -DCONFIG_BLUETOOTH_CENTRAL -DCONFIG_BLUETOOTH_GATT_CLIENT
+compiler.c.flags=-c -std=gnu11 -mcpu=quarkse_em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -fsigned-char -MMD -D__ARDUINO_ARC__ -DCONFIG_BLUETOOTH_PERIPHERAL -DCONFIG_BLUETOOTH_CENTRAL -DCONFIG_BLUETOOTH_GATT_CLIENT -D__CPU_ARC__ -DCLOCK_SPEED=32 -DCONFIG_SOC_GPIO_32 -DCONFIG_SOC_GPIO_AON -DINFRA_MULTI_CPU_SUPPORT -DCFW_MULTI_CPU_SUPPORT -DHAS_SHARED_MEM "-I{build.system.path}/libarc32_arduino101/common" "-I{build.system.path}/libarc32_arduino101/drivers" "-I{build.system.path}/libarc32_arduino101/bootcode" "-I{build.system.path}/libarc32_arduino101/framework/include"
 compiler.c.elf.cmd=arc-elf32-gcc
 compiler.c.elf.flags=-nostartfiles -nodefaultlibs -nostdlib -static -Wl,-X -Wl,-N -Wl,-mcpu=quarkse_em -Wl,-marcelf -Wl,--gc-sections
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=arc-elf32-g++
-compiler.cpp.flags=-c -mcpu=quarkse_em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -fsigned-char -MMD -fno-rtti -fno-exceptions -fcheck-new -D__ARDUINO_ARC__ -std=c++11 -DCONFIG_BLUETOOTH_PERIPHERAL -DCONFIG_BLUETOOTH_CENTRAL -DCONFIG_BLUETOOTH_GATT_CLIENT
+compiler.cpp.flags=-c -mcpu=quarkse_em -mlittle-endian -g -Os -Wall -fno-reorder-functions -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -fno-defer-pop -Wno-unused-but-set-variable -Wno-main -ffreestanding -fno-stack-protector -mno-sdata -ffunction-sections -fdata-sections -fsigned-char -MMD -fno-rtti -fno-exceptions -fcheck-new -D__ARDUINO_ARC__ -std=c++11 -DCONFIG_BLUETOOTH_PERIPHERAL -DCONFIG_BLUETOOTH_CENTRAL -DCONFIG_BLUETOOTH_GATT_CLIENT -D__CPU_ARC__ -DCLOCK_SPEED=32 -DCONFIG_SOC_GPIO_32 -DCONFIG_SOC_GPIO_AON -DINFRA_MULTI_CPU_SUPPORT -DCFW_MULTI_CPU_SUPPORT -DHAS_SHARED_MEM "-I{build.system.path}/libarc32_arduino101/common" "-I{build.system.path}/libarc32_arduino101/drivers" "-I{build.system.path}/libarc32_arduino101/bootcode" "-I{build.system.path}/libarc32_arduino101/framework/include"
 compiler.ar.cmd=arc-elf32-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arc-elf32-objcopy
@@ -37,9 +37,9 @@ compiler.strip.cmd={compiler.prefix}-strip
 build.extra_flags=
 
 # These can be overridden in platform.local.txt
-compiler.c.extra_flags=-D__CPU_ARC__ -DCLOCK_SPEED=32 -DCONFIG_SOC_GPIO_32 -DCONFIG_SOC_GPIO_AON -DINFRA_MULTI_CPU_SUPPORT -DCFW_MULTI_CPU_SUPPORT -DHAS_SHARED_MEM "-I{build.system.path}/libarc32_arduino101/common" "-I{build.system.path}/libarc32_arduino101/drivers" "-I{build.system.path}/libarc32_arduino101/bootcode" "-I{build.system.path}/libarc32_arduino101/framework/include"
+compiler.c.extra_flags=
 compiler.c.elf.extra_flags=
-compiler.cpp.extra_flags=-D__CPU_ARC__ -DCLOCK_SPEED=32 -DCONFIG_SOC_GPIO_32 -DCONFIG_SOC_GPIO_AON -DINFRA_MULTI_CPU_SUPPORT -DCFW_MULTI_CPU_SUPPORT -DHAS_SHARED_MEM "-I{build.system.path}/libarc32_arduino101/common" "-I{build.system.path}/libarc32_arduino101/drivers" "-I{build.system.path}/libarc32_arduino101/bootcode" "-I{build.system.path}/libarc32_arduino101/framework/include"
+compiler.cpp.extra_flags=
 compiler.ar.extra_flags=
 compiler.elf2hex.extra_flags=
 


### PR DESCRIPTION
resolves #599

By leaving extra_flags empty, we leave a hook for the end-user to use
without having to duplicate a bunch of flags. This matches how the AVR
core leaves the extra_flags blank.